### PR TITLE
Rename routes module to PhoenixKitPublishing.Routes

### DIFF
--- a/lib/phoenix_kit_publishing/publishing.ex
+++ b/lib/phoenix_kit_publishing/publishing.ex
@@ -323,7 +323,7 @@ defmodule PhoenixKit.Modules.Publishing do
   def children, do: [PhoenixKit.Modules.Publishing.Presence]
 
   @impl PhoenixKit.Module
-  def route_module, do: PhoenixKitWeb.Routes.PublishingRoutes
+  def route_module, do: PhoenixKitPublishing.Routes
 
   @impl PhoenixKit.Module
   def css_sources, do: ["phoenix_kit_publishing"]

--- a/lib/phoenix_kit_publishing/routes.ex
+++ b/lib/phoenix_kit_publishing/routes.ex
@@ -1,4 +1,4 @@
-defmodule PhoenixKitWeb.Routes.PublishingRoutes do
+defmodule PhoenixKitPublishing.Routes do
   @moduledoc """
   Publishing module routes.
 


### PR DESCRIPTION
Was using the old internal namespace PhoenixKitWeb.Routes.PublishingRoutes from before extraction. Aligns with the convention used by entities, ai, and sync modules.