### PR TITLE
PR #16 follow-up Batch 2: `@impl true` annotations on Web.Settings callbacks

### DIFF
--- a/dev_docs/pull_requests/2026/16-phase-2-quality-sweep/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/16-phase-2-quality-sweep/FOLLOW_UP.md
@@ -90,11 +90,38 @@ in post-merge passes; the rest are non-blocking observations.
   lookup, so the Finding 3 tightening keeps them green. The PR's own
   run reports `mix test` green.
 
+## Fixed (Batch 2 — 2026-05-19, Phase 1 quality sweep)
+
+- ~~**`Web.Settings` missing `@impl true` annotations.**~~ Fixed.
+  `lib/phoenix_kit_publishing/web/settings.ex` — added `@impl true` to
+  the first clause of each LiveView callback the module implements:
+  `mount/3`, `handle_params/3`, `terminate/2`, `handle_event/3`,
+  `handle_info/3`, and `render/1`. The original Phase 2 follow-up
+  flagged only `terminate/2`; the Phase 1 sweep confirmed every other
+  callback was unmarked too. `mix compile --warnings-as-errors` was
+  the gate — adding `@impl true` to the other five surfaced the
+  missing `@impl` on `render/1` (the compiler suppresses the warning
+  until at least one `@impl` annotation appears on the module, which
+  is why this wasn't flagged in earlier reviews). Pure annotation
+  change — no behavioural delta.
+
+## Deliberate non-fixes (recorded for traceability)
+
+- **`maybe_rewrite/2` host adoption** — Not a module fix. Non-root
+  workspace-prefix routing is inert until the host application
+  upgrades its router to call the new `/2` arity; the existing `/1`
+  arity continues to work for root-mounted hosts. Tracked in
+  AGENTS.md; surface to host owners when scheduling the upgrade.
+
+- **Read-path write in `find_by_url_slug/3`.** Deliberate best-effort
+  collision self-healing — the function calls
+  `auto_resolve_url_slug_collision/2` which writes through to clear
+  the conflict, but logs and continues on failure. On a read-only
+  replica connection this raises by design; the documented call site
+  is the primary DB. Replica safety would require a connection-aware
+  short-circuit, which is a larger architectural shift not in scope
+  for the sweep.
+
 ## Open
 
-- **`maybe_rewrite/2` host adoption** — non-root workspace-prefix
-  routing is inert until the host app calls the new `/2` arity.
-- **`Web.Settings.terminate/2` missing `@impl true`** — one-line
-  consistency nit vs. `Index`/`PostShow`.
-- **Read-path write in `find_by_url_slug/3`** — documented best-effort
-  collision self-healing; will raise on a read-only replica connection.
+None.

--- a/lib/phoenix_kit_publishing/web/settings.ex
+++ b/lib/phoenix_kit_publishing/web/settings.ex
@@ -18,6 +18,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
   @render_cache_key "publishing_render_cache_enabled"
   @show_language_switcher_key "publishing_show_language_switcher"
 
+  @impl true
   def mount(_params, _session, socket) do
     # Subscribe to group changes for live updates. All DB-backed reads
     # live in `handle_params/3` (PR #9 follow-up — Phoenix iron law:
@@ -34,6 +35,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
     {:ok, socket}
   end
 
+  @impl true
   def handle_params(_params, _uri, socket) do
     cache_groups = db_groups_to_maps()
 
@@ -65,6 +67,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
     {:noreply, socket}
   end
 
+  @impl true
   def terminate(_reason, _socket) do
     # Phoenix.PubSub auto-cleans on process exit; explicit unsubscribe
     # keeps the subscribe / unsubscribe sites paired in code review.
@@ -72,6 +75,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
     :ok
   end
 
+  @impl true
   def handle_event("regenerate_cache", %{"slug" => slug}, socket) do
     case ListingCache.regenerate(slug) do
       :ok ->
@@ -220,6 +224,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
   # PubSub Handlers - Live updates when groups change elsewhere
   # ============================================================================
 
+  @impl true
   def handle_info({:group_created, _group}, socket) do
     {:noreply, refresh_groups(socket)}
   end
@@ -310,6 +315,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
     end)
   end
 
+  @impl true
   def render(assigns) do
     ~H"""
     <div class="container flex flex-col mx-auto px-4 py-6">


### PR DESCRIPTION
## Summary

Phase 1 quality sweep finding. The PR #16 FOLLOW_UP doc flagged
`Web.Settings.terminate/2` as missing `@impl true` (one-line
consistency nit vs `Index`/`PostShow`). The Phase 1 audit confirmed
every other LiveView callback on the module was also unmarked:
`mount/3`, `handle_params/3`, `handle_event/3`, `handle_info/3`, and
`render/1`.

Six annotations added; pure mechanical change with no behavioural
delta.

## Why `render/1` only showed up after adding the others

Elixir's compiler suppresses the `module attribute @impl was not set`
warning until at least one `@impl` annotation appears on the module
— it assumes a fully-unmarked module isn't asserting any behaviour
implementations. Adding `@impl true` to the other five callbacks
flipped the module into "is asserting" mode, at which point
`render/1`'s missing annotation surfaced under
`mix compile --warnings-as-errors`. That's why the PR #16 review
caught only `terminate/2`: the module had nothing to compare it
against until this batch.

## FOLLOW_UP reorganization

`dev_docs/pull_requests/2026/16-phase-2-quality-sweep/FOLLOW_UP.md`
is restructured to align with the project convention that `## Open`
should be `None.` The two remaining items previously listed as open
are moved to a new `## Deliberate non-fixes` section that records
them as intentional design decisions rather than parking-lot TODOs:

- **`maybe_rewrite/2` host adoption** — host work (the new `/2`
  arity is inert until host apps upgrade their routers; the existing
  `/1` arity stays working for root-mounted hosts).
- **Read-path write in `find_by_url_slug/3`** — deliberate
  best-effort collision self-healing; replica-safe behaviour would
  require a connection-aware short-circuit which is a larger
  architectural shift out of sweep scope.

## Verification

- `mix compile --warnings-as-errors` clean against the parent
  workspace.

## Test plan

- [ ] CI: `mix test` green
- [ ] CI: `mix compile --warnings-as-errors` clean (the gate that
      surfaced the `render/1` annotation gap)