### PR TITLE
Defensive fallback for non-binary input to parse_translated_response/1

### DIFF
--- a/lib/phoenix_kit_publishing/workers/translate_post_worker.ex
+++ b/lib/phoenix_kit_publishing/workers/translate_post_worker.ex
@@ -418,7 +418,7 @@ defmodule PhoenixKit.Modules.Publishing.Workers.TranslatePostWorker do
   # would have fallen back to markdown for re-ordered responses.
   # This is an improvement; regression test
   # `"parses markers in any order"` documents the new contract.
-  def parse_translated_response(response) do
+  def parse_translated_response(response) when is_binary(response) do
     case Translation.parse_response(response, ["title", "slug", "content"]) do
       {:ok, fields} ->
         {extract_field(fields, "title"), sanitize_slug_if_present(fields["slug"]),
@@ -432,6 +432,13 @@ defmodule PhoenixKit.Modules.Publishing.Workers.TranslatePostWorker do
         {title, nil, content}
     end
   end
+
+  # Fail closed for nil / non-binary input rather than letting
+  # `Translation.parse_response/2`'s `is_binary/1` guard raise a
+  # FunctionClauseError. The AI extract pipeline always feeds us
+  # strings, but the function is `def` (public for testing) so a
+  # test or external caller can hand us anything.
+  def parse_translated_response(_other), do: {"", nil, ""}
 
   # Re-attempt parsing against title+content only (no slug). Matches
   # the format used by older prompts that don't ask for a slug. Falls

--- a/lib/phoenix_kit_publishing/workers/translate_post_worker.ex
+++ b/lib/phoenix_kit_publishing/workers/translate_post_worker.ex
@@ -438,7 +438,39 @@ defmodule PhoenixKit.Modules.Publishing.Workers.TranslatePostWorker do
   # FunctionClauseError. The AI extract pipeline always feeds us
   # strings, but the function is `def` (public for testing) so a
   # test or external caller can hand us anything.
-  def parse_translated_response(_other), do: {"", nil, ""}
+  #
+  # If this clause ever fires in production we'd persist a blank
+  # translation row — log a warning so ops can investigate. Keep
+  # the log low-detail (only the type + module of structs, never
+  # the full value) so AI response payloads / PII don't leak into
+  # logs. Test calls hit the same warning, which is noisy by
+  # design — tests pass an explicit `nil`/atom/number, so the
+  # operator-visible signal is correct: "this path was exercised".
+  def parse_translated_response(other) do
+    Logger.warning(
+      "[TranslatePostWorker] parse_translated_response/1 fallback fired " <>
+        "for non-binary input (type=#{describe_type(other)}). " <>
+        "This would persist a blank translation in production."
+    )
+
+    {"", nil, ""}
+  end
+
+  # Returns a short, log-safe description of a value's shape — never
+  # the value itself. Structs identify by module name; primitives
+  # report their type only.
+  defp describe_type(%mod{}), do: "struct:#{inspect(mod)}"
+  defp describe_type(v) when is_nil(v), do: "nil"
+  defp describe_type(v) when is_atom(v), do: "atom"
+  defp describe_type(v) when is_integer(v), do: "integer"
+  defp describe_type(v) when is_float(v), do: "float"
+  defp describe_type(v) when is_map(v), do: "map(size=#{map_size(v)})"
+  defp describe_type(v) when is_list(v), do: "list(len=#{length(v)})"
+  defp describe_type(v) when is_tuple(v), do: "tuple(size=#{tuple_size(v)})"
+  defp describe_type(v) when is_pid(v), do: "pid"
+  defp describe_type(v) when is_reference(v), do: "reference"
+  defp describe_type(v) when is_function(v), do: "function"
+  defp describe_type(_), do: "unknown"
 
   # Re-attempt parsing against title+content only (no slug). Matches
   # the format used by older prompts that don't ask for a slug. Falls

--- a/lib/phoenix_kit_publishing/workers/translate_post_worker.ex
+++ b/lib/phoenix_kit_publishing/workers/translate_post_worker.ex
@@ -465,12 +465,29 @@ defmodule PhoenixKit.Modules.Publishing.Workers.TranslatePostWorker do
   defp describe_type(v) when is_integer(v), do: "integer"
   defp describe_type(v) when is_float(v), do: "float"
   defp describe_type(v) when is_map(v), do: "map(size=#{map_size(v)})"
-  defp describe_type(v) when is_list(v), do: "list(len=#{length(v)})"
   defp describe_type(v) when is_tuple(v), do: "tuple(size=#{tuple_size(v)})"
   defp describe_type(v) when is_pid(v), do: "pid"
   defp describe_type(v) when is_reference(v), do: "reference"
   defp describe_type(v) when is_function(v), do: "function"
+
+  # `length/1` only works on proper lists — calling it on an improper
+  # list like `[:a | :b]` raises `ArgumentError`. The describe path
+  # is defensive itself; crashing here would defeat the point. Use
+  # `:proper` vs `:improper` as the label and skip the length on
+  # improper lists.
+  defp describe_type(v) when is_list(v) do
+    if proper_list?(v) do
+      "list(len=#{length(v)})"
+    else
+      "list(improper)"
+    end
+  end
+
   defp describe_type(_), do: "unknown"
+
+  defp proper_list?([]), do: true
+  defp proper_list?([_ | tail]) when is_list(tail), do: proper_list?(tail)
+  defp proper_list?(_), do: false
 
   # Re-attempt parsing against title+content only (no slug). Matches
   # the format used by older prompts that don't ask for a slug. Falls

--- a/test/phoenix_kit_publishing/translate_post_worker_test.exs
+++ b/test/phoenix_kit_publishing/translate_post_worker_test.exs
@@ -302,6 +302,18 @@ defmodule PhoenixKit.Modules.Publishing.TranslatePostWorkerTest do
       assert content =~ "Mixed case content"
     end
 
+    test "non-binary input fails closed with empty tuple (defensive)" do
+      # `parse_translated_response/1` is `def` (public for testing).
+      # `Translation.parse_response/2` guards on `is_binary/1`, so
+      # passing nil / atom / number would crash with FunctionClauseError.
+      # Defensive fallback returns the empty-tuple shape so a test or
+      # external caller can hand us anything without crashing the worker.
+      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(nil)
+      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(:atom)
+      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(123)
+      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(%{})
+    end
+
     test "only TITLE present (no CONTENT, no SLUG) falls back to markdown salvage with empty values" do
       # When parse_response/2 returns missing_fields for ["title",
       # "slug", "content"], we retry with ["title", "content"]. If

--- a/test/phoenix_kit_publishing/translate_post_worker_test.exs
+++ b/test/phoenix_kit_publishing/translate_post_worker_test.exs
@@ -302,16 +302,35 @@ defmodule PhoenixKit.Modules.Publishing.TranslatePostWorkerTest do
       assert content =~ "Mixed case content"
     end
 
-    test "non-binary input fails closed with empty tuple (defensive)" do
+    test "non-binary input fails closed with empty tuple + warning log (defensive)" do
       # `parse_translated_response/1` is `def` (public for testing).
       # `Translation.parse_response/2` guards on `is_binary/1`, so
       # passing nil / atom / number would crash with FunctionClauseError.
       # Defensive fallback returns the empty-tuple shape so a test or
       # external caller can hand us anything without crashing the worker.
-      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(nil)
-      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(:atom)
-      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(123)
-      assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(%{})
+      #
+      # The fallback ALSO emits a `Logger.warning` — if this clause
+      # ever fires in production it would persist a blank translation
+      # row, so ops needs the visible signal. The log carries the
+      # input's TYPE only (never the value itself, to avoid leaking
+      # PII / API keys in pathological inputs). Test config sets
+      # `config :logger, level: :warning`, so `Logger.warning` is
+      # not filtered — no need to bump the level per-test.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(nil)
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(:atom)
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(123)
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(%{"k" => "v"})
+        end)
+
+      assert log =~ "parse_translated_response/1 fallback fired"
+      assert log =~ "type=nil"
+      assert log =~ "type=atom"
+      assert log =~ "type=integer"
+      assert log =~ "type=map(size=1)"
+      # Map contents must NEVER appear in the log:
+      refute log =~ "\"k\" => \"v\""
     end
 
     test "only TITLE present (no CONTENT, no SLUG) falls back to markdown salvage with empty values" do

--- a/test/phoenix_kit_publishing/translate_post_worker_test.exs
+++ b/test/phoenix_kit_publishing/translate_post_worker_test.exs
@@ -321,16 +321,56 @@ defmodule PhoenixKit.Modules.Publishing.TranslatePostWorkerTest do
           assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(nil)
           assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(:atom)
           assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(123)
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(1.5)
           assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(%{"k" => "v"})
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(["a", "b"])
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response({:tuple, 2})
+          assert {"", nil, ""} = TranslatePostWorker.parse_translated_response(self())
         end)
 
       assert log =~ "parse_translated_response/1 fallback fired"
       assert log =~ "type=nil"
       assert log =~ "type=atom"
       assert log =~ "type=integer"
+      assert log =~ "type=float"
       assert log =~ "type=map(size=1)"
-      # Map contents must NEVER appear in the log:
+      assert log =~ "type=list(len=2)"
+      assert log =~ "type=tuple(size=2)"
+      assert log =~ "type=pid"
+      # Map / list / tuple contents must NEVER appear in the log:
       refute log =~ "\"k\" => \"v\""
+      refute log =~ ":tuple"
+      refute log =~ "\"a\""
+    end
+
+    test "improper list input doesn't crash the descriptor" do
+      # `length/1` raises `ArgumentError` on improper lists. The
+      # `proper_list?/1` guard in `describe_type/1` keeps the
+      # defensive path itself defensive — falling through to
+      # `list(improper)` instead of letting the helper crash and
+      # propagate a worker error.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {"", nil, ""} =
+                   TranslatePostWorker.parse_translated_response([:a | :b])
+        end)
+
+      assert log =~ "type=list(improper)"
+    end
+
+    test "struct input is described by module name, not field values" do
+      # Real risk: a `%Plug.Conn{}` or `%MyApp.User{}` accidentally
+      # threaded through carries gobs of PII. The descriptor must
+      # surface ONLY the module name.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {"", nil, ""} =
+                   TranslatePostWorker.parse_translated_response(%URI{scheme: "https"})
+        end)
+
+      assert log =~ "type=struct:URI"
+      # URI's struct values must not appear:
+      refute log =~ "https"
     end
 
     test "only TITLE present (no CONTENT, no SLUG) falls back to markdown salvage with empty values" do


### PR DESCRIPTION
## Summary

After PR #19 refactored `TranslatePostWorker.parse_translated_response/1`
to delegate to core's `Translation.parse_response/2`, the function
became binary-input-only — `Translation.parse_response/2`'s
`is_binary/1` guard raises `FunctionClauseError` on `nil` / atom /
number input.

`parse_translated_response/1` is `def` (public for testing), so a
test or external caller can still hand it anything. The pre-refactor
regex chain handled non-binary input by simply not matching and
falling through to the markdown-salvage tuple — this PR restores
that defensive posture with an explicit guarded clause + a
fallthrough that returns the empty-tuple shape `{"", nil, ""}`.

## Notes

- Surfaced during PR #19 review; landed late on the merged branch
  and got orphaned. This PR re-applies it cleanly off `upstream/main`.
- The AI extract pipeline always feeds the worker strings — this is
  pure defense-in-depth for the public-for-testing surface.

## Test plan

- [x] `mix compile` clean
- [x] `mix format --check-formatted` clean on touched files
- [x] `mix test test/phoenix_kit_publishing/translate_post_worker_test.exs` — 38/38 pass
- [x] New test pins `{"", nil, ""}` shape for `nil`, atom, number, map inputs