### PR TITLE
Reuse core AI-translation availability helpers + PR #20 follow-up

### DIFF
--- a/dev_docs/pull_requests/2026/20-parse-response-non-binary-fallback/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/20-parse-response-non-binary-fallback/FOLLOW_UP.md
@@ -1,0 +1,65 @@
+# PR #20 — Follow-up
+
+PR is merged into `main` (merge commit `b68b68f`, version bump landed
+in `6cc6511` → 0.1.13). Companion `CLAUDE_REVIEW.md` + `README.md`
+in this folder.
+
+## Fixed (post-merge, on `main`)
+
+- **NITPICK — idiomatic `nil` head.** `describe_type(v) when is_nil(v)`
+  → literal head `describe_type(nil)`. `nil` is still matched before
+  the `is_atom/1` clause, same as before — pure style cleanup.
+  (commit `29dbeb7`)
+- **IMPROVEMENT — coverage gap on non-byte-aligned bitstring.** Added
+  `describe_type(v) when is_bitstring(v), do: "bitstring"`. The
+  public `parse_translated_response/1` clause already handles
+  `is_binary/1` (a byte-aligned bitstring), so only a non-aligned
+  bitstring like `<<1::3>>` can reach the fallback. Previously
+  reported as `"unknown"`. Test extended with the matching assertion.
+  (commit `29dbeb7`)
+
+## Skipped — recorded for team decision
+
+- **Fail-closed (blank row) vs. fail-loud (error tuple).** When the
+  AI provider returns `"content": null`, `AI.extract_content/1`
+  produces `{:ok, nil}` and the fallback fires in production —
+  persisting a blank translation row with only a `Logger.warning`
+  as signal. The "AI extract pipeline always feeds us strings"
+  comment in the worker is slightly optimistic.
+
+  - **Argument to keep fail-closed (current):** a non-binary is a
+    *type* error, not a transient failure, so an Oban retry wouldn't
+    help; the warning preserves observability without losing the
+    rest of the batch.
+  - **Argument to fail loud:** a persisted blank row is a
+    data-quality problem that may go unnoticed despite the log line;
+    overwrites and duplicates are harder to detect after the fact
+    than a failed job.
+
+  Surfaced to Max as a behavior/product call rather than a
+  correctness bug. No code change in this pass; documented here so
+  the next maintainer touching the worker doesn't re-derive the
+  question.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `lib/phoenix_kit_publishing/workers/translate_post_worker.ex` | `nil` literal head; `+is_bitstring/1` clause |
+| `test/phoenix_kit_publishing/translate_post_worker_test.exs` | `+1` bitstring assertion in the fallback log test |
+| `dev_docs/pull_requests/2026/20-parse-response-non-binary-fallback/CLAUDE_REVIEW.md` | Post-merge review |
+| `dev_docs/pull_requests/2026/20-parse-response-non-binary-fallback/README.md` | PR overview |
+
+## Verification
+
+- `mix compile --warnings-as-errors` — clean
+- `mix format --check-formatted` — clean
+- `mix dialyzer` — 0 errors
+- `mix test test/phoenix_kit_publishing/translate_post_worker_test.exs` — 41/41 pass
+  (post-merge run; the test file is pure unit tests on
+  `parse_translated_response/1` and needs no DB)
+
+## Open
+
+None. The fail-closed-vs-fail-loud item is a decision surfaced to
+Max, not an unfixed finding.

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -8,6 +8,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
 
   use Gettext, backend: PhoenixKitWeb.Gettext
 
+  alias PhoenixKit.Modules.AI.Translations
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PresenceHelpers
@@ -22,41 +23,30 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   # Availability Checks
   # ============================================================================
 
+  # Availability + endpoint/prompt listing are generic across every
+  # AI-translation consumer, so they delegate to core
+  # `PhoenixKit.Modules.AI.Translations` — the canonical implementation —
+  # rather than re-deriving the same `{uuid, name}` shape here. (Catalogue
+  # and projects share the same core helpers.) Publishing keeps its own
+  # *default* endpoint/prompt resolution below, since those read
+  # publishing-specific setting keys + the publishing-specific prompt slug.
+
   @doc """
   Checks if AI translation is available (AI module installed + enabled + endpoints configured).
   """
-  def ai_translation_available? do
-    ai_module_available?() and AI.enabled?() and list_ai_endpoints() != []
-  end
+  def ai_translation_available?, do: Translations.available?()
 
   defp ai_module_available?, do: Code.ensure_loaded?(PhoenixKitAI)
 
   @doc """
-  Lists available AI endpoints for translation.
+  Lists available AI endpoints for translation as `[{uuid, name}]`.
   """
-  def list_ai_endpoints do
-    if ai_module_available?() and AI.enabled?() do
-      # Use UUID for dropdown values (stable across systems, matches settings storage)
-      {endpoints, _total} = AI.list_endpoints(enabled: true)
-      Enum.map(endpoints, &{&1.uuid, &1.name})
-    else
-      []
-    end
-  end
+  def list_ai_endpoints, do: Translations.list_endpoints()
 
   @doc """
-  Lists available AI prompts for translation.
+  Lists available AI prompts for translation as `[{uuid, name}]`.
   """
-  def list_ai_prompts do
-    if ai_module_available?() and AI.enabled?() do
-      case AI.list_prompts(enabled: true) do
-        {prompts, _total} -> Enum.map(prompts, &{&1.uuid, &1.name})
-        prompts when is_list(prompts) -> Enum.map(prompts, &{&1.uuid, &1.name})
-      end
-    else
-      []
-    end
-  end
+  def list_ai_prompts, do: Translations.list_prompts()
 
   @doc """
   Gets the default AI endpoint UUID from settings.


### PR DESCRIPTION
## Summary

Small dedupe: three helpers (`ai_translation_available?/0`, `list_ai_endpoints/0`, `list_ai_prompts/0`) were byte-for-byte re-implementations of helpers core now exposes (`PhoenixKit.Modules.AI.Translations`). They delegate to core instead, removing the drift risk between copies. Publishing's own default endpoint/prompt resolution and its `translate-publishing-posts` prompt are kept — its versioned per-language-row storage, sequential worker, and controller-driven editor are deliberately unchanged (they don't fit the per-language-fan-out / JSONB / LiveView pipeline).

### PR follow-up
- `192b7e0` — `FOLLOW_UP.md` for PR #20 (parse_response non-binary fallback), Phase 1 catch-up.

### Dedupe
- `91e7683` — the three helpers now delegate to core `Translations`; shape + guard parity verified (core's `safe_ai` wrapper is stricter than the old local `ai_module_available? and AI.enabled?` check).

## Verification
- `mix format --check-formatted` clean; compiles via the integration app; the three helpers' callers (`editor.ex`) unchanged and verified.

## Note
Consumes the core AI-translation generalization (BeamLabEU/phoenix_kit#582) — needs a release containing it before it builds standalone.