### PR TITLE
Move AI translation to phoenix_kit_ai; version-scoped translation; editor fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,8 +509,12 @@ PR review files go in `dev_docs/pull_requests/{year}/{pr_number}-{slug}/` direct
 
 ## External Dependencies
 
-- **PhoenixKit** (`~> 1.7`) — Module behaviour, Settings API, shared components, RepoHelper
-- **PhoenixKitAI** (`~> 0.1`) — AI translation dispatch (OpenRouter via core's `AI.ask_with_prompt/4`)
+- **PhoenixKit** (`~> 1.7.132`) — Module behaviour, Settings API, shared components, RepoHelper
+- **PhoenixKitAI** (`~> 0.3`) — the AI-translation pipeline lives here (moved out of core): the
+  `PhoenixKitAI.Translatable` adapter behaviour (publishing's `AITranslatable` implements it),
+  `PhoenixKitAI.{Translations,TranslateWorker,Translation}`, and the `AITranslate` modal UI. The
+  per-language Oban fan-out + the LLM call (`PhoenixKitAI.ask_with_prompt/4`, OpenRouter) are owned
+  by this plugin; publishing only contributes the adapter + editor wiring.
 - **Phoenix LiveView** (`~> 1.0`) — Admin LiveViews
 - **Earmark** (`~> 1.4`) — Markdown rendering (GFM)
 - **Saxy** (`~> 1.5`) — XML parsing for PHK page builder components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,27 @@ mix quality.ci                                # format --check-formatted + credo
 mix docs                                      # Generate documentation
 ```
 
+## Local cross-repo development
+
+`phoenix_kit` (and any sibling `phoenix_kit_*` dep) resolves from Hex by
+default. To build or test this module against a **local checkout** of a
+dependency — e.g. an unpublished core change — export `<APP>_PATH` and Mix
+swaps the Hex pin for a `path:` + `override: true` dep at resolve time:
+
+```bash
+PHOENIX_KIT_PATH=../phoenix_kit mix test     # this module against local core
+PHOENIX_KIT_AI_PATH=../phoenix_kit_ai mix test
+```
+
+The variable name is the dep's app name upper-cased with `_PATH` appended
+(`:phoenix_kit` -> `PHOENIX_KIT_PATH`, `:phoenix_kit_ai` ->
+`PHOENIX_KIT_AI_PATH`). Set several at once to override multiple deps. This
+module's sibling overrides: `PHOENIX_KIT_AI_PATH`. **Unset = the
+published pin**, so `mix hex.publish` and CI resolve exactly as before.
+Implemented via `pk_dep/3` in `mix.exs` — never hand-edit a `phoenix_kit*`
+dep into a `path:` tuple (a committed path dep ships a broken package); set
+the env var instead.
+
 ## Architecture
 
 This is a **library** (not a standalone Phoenix app) that provides publishing/CMS capabilities as a PhoenixKit plugin module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ## 0.1.14 - 2026-06-07
 
-PR #21 + PR #22 — editor UX, configurable slug style, and parallel AI translation (one Oban job per language via core's generic pipeline), plus a post-merge review sweep. Requires `phoenix_kit ~> 1.7.132`.
+PR #21 + PR #22 — editor UX, configurable slug style, and parallel AI translation (one Oban job per language via the shared translation pipeline), plus a post-merge review sweep. Requires `phoenix_kit ~> 1.7.132`.
 
 ### Added
 - **Configurable slug style** (`publishing_slug_style` setting + Settings dropdown). One style-aware `SlugHelpers.slugify/2` that every slug engine routes through: `transliterate` (default — Cyrillic → Latin, `Привет мир` → `privet-mir`), `unicode` (keep letters/numbers from any script, `привет-мир`), and `ascii` (legacy strip). Non-Latin titles no longer collapse to "untitled". Slugs are capped at 200 chars on a hyphen boundary.
-- **`PhoenixKitPublishing.AITranslatable`** — adapter onto core's generic AI-translation pipeline (`PhoenixKit.Modules.AI.{Translations,TranslateWorker}`), registered via `ai_translatables/0`. The per-language `url_slug` is generated locally from the translated title (honoring the slug style, never trusting an AI-returned slug) with a group+language uniqueness guard that omits the slug on conflict.
+- **`PhoenixKitPublishing.AITranslatable`** — adapter onto PhoenixKitAI's generic AI-translation pipeline (`PhoenixKitAI.{Translations,TranslateWorker}`), registered via `ai_translatables/0`. The per-language `url_slug` is generated locally from the translated title (honoring the slug style, never trusting an AI-returned slug) with a group+language uniqueness guard that omits the slug on conflict.
 - Editor UX: full-width layout matching the catalogue, aligned header rows, the public URL shown under the action buttons on published posts, and the re-enabled per-language URL Slug field with live preview.
 
 ### Changed
-- **AI translation now runs one Oban job per target language** (core's `Translations.enqueue_all_missing/2`) instead of translating every language sequentially in a single job — wall-clock drops from the sum of all languages to roughly the slowest one. The programmatic `translate_post_to_all_languages/3` routes through the same pipeline.
-- `ai_translation_available?/0`, `list_ai_endpoints/0`, and `list_ai_prompts/0` delegate to core `PhoenixKit.Modules.AI.Translations` instead of re-deriving the `{uuid, name}` shape a third time (PR #21). Publishing keeps its own default endpoint/prompt resolution and its `translate-publishing-posts` prompt.
+- **AI translation now runs one Oban job per target language** (`PhoenixKitAI.Translations.enqueue_all_missing/2`) instead of translating every language sequentially in a single job — wall-clock drops from the sum of all languages to roughly the slowest one. The programmatic `translate_post_to_all_languages/3` routes through the same pipeline.
+- `ai_translation_available?/0`, `list_ai_endpoints/0`, and `list_ai_prompts/0` delegate to `PhoenixKitAI.Translations` instead of re-deriving the `{uuid, name}` shape a third time (PR #21). Publishing keeps its own default endpoint/prompt resolution and its `translate-publishing-posts` prompt.
 - The `url_slug` uniqueness check now excludes the current post **in SQL**.
-- Bumped the `phoenix_kit` dependency floor to `~> 1.7.132` (first release with the generic AI-translation pipeline this module plugs into).
+- Added/updated the `phoenix_kit_ai` dependency for the generic AI-translation pipeline this module plugs into.
 
 ### Fixed
 - **Translation source is always the primary language**, never the language the editor happens to be viewing — "translate this language" on a non-primary page no longer enqueues a language into itself, and "translate all/missing" no longer sources from a translation. Covers the `source_content_blank?/1` blank-source confirmation warning.
@@ -22,7 +22,7 @@ PR #21 + PR #22 — editor UX, configurable slug style, and parallel AI translat
 - The in-flight translation query references the core worker module instead of a hardcoded string, and a dead `|| %{}` guard on the always-a-map `post.metadata` was removed (Dialyzer).
 
 ### Removed
-- The legacy `Workers.TranslatePostWorker` and its tests — superseded by the `AITranslatable` adapter + core pipeline (net −1.3k LOC).
+- The legacy `Workers.TranslatePostWorker` and its tests — superseded by the `AITranslatable` adapter + PhoenixKitAI pipeline (net −1.3k LOC).
 
 ## 0.1.13 - 2026-05-22
 
@@ -41,8 +41,8 @@ PR #20 — restore a defensive non-binary fallback in `TranslatePostWorker.parse
 PR #19 — unify the translation-response parser with core (paired with `phoenix_kit 1.7.117`).
 
 ### Changed
-- `TranslatePostWorker.parse_translated_response/1` now delegates to `PhoenixKit.Modules.AI.Translation.parse_response/2` (the canonical `---FIELD---` parser shared with `phoenix_kit_projects`, shipped in core PR #557) instead of a hand-rolled chained-regex matcher. It tries `["title", "slug", "content"]` first, retries with `["title", "content"]` on missing fields, and falls back to the publishing-specific `parse_markdown_response/1` salvage when no markers are present. The AI call sites, `extract_content/1`, and `sanitize_slug/1` are untouched.
-- Bumped the `phoenix_kit` dependency floor to `~> 1.7.117`, which is where `Modules.AI.Translation.parse_response/2` became available; the lock also picks up `etcher 0.4.6`, `fresco 0.5.4`, and `req 0.5.18`.
+- `TranslatePostWorker.parse_translated_response/1` now delegates to the shared `Translation.parse_response/2` helper (the canonical `---FIELD---` parser shared with `phoenix_kit_projects`) instead of a hand-rolled chained-regex matcher. It tries `["title", "slug", "content"]` first, retries with `["title", "content"]` on missing fields, and falls back to the publishing-specific `parse_markdown_response/1` salvage when no markers are present. The AI call sites, `extract_content/1`, and `sanitize_slug/1` are untouched.
+- Bumped the `phoenix_kit` dependency floor to `~> 1.7.117`, which is where the shared translation parser became available; the lock also picks up `etcher 0.4.6`, `fresco 0.5.4`, and `req 0.5.18`.
 
 ### Fixed
 - Translation responses with `---FIELD---` markers in any order, or with lower/mixed-case marker names, now parse correctly instead of falling through to the bare-markdown salvage path. Covered by new regression tests for marker order-independence, case-insensitive markers, and the TITLE-only fallback.

--- a/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
@@ -53,6 +53,57 @@ Codex flagged two genuine HIGH bugs in the AI-translation path (both verified):
   pins the resolved version in `fetch/2` and threads it through both the read
   and the write. (`lib/phoenix_kit_publishing/ai_translatable.ex`)
 
+## Fixed (Batch 4 — live browser test, 2026-06-07)
+
+Ran a real end-to-end AI translation in Chrome (dev server, parent app) instead
+of trusting only the data-layer tests — opened a post on its **ru** (non-primary)
+page and translated en-US → ru. This surfaced **two real bugs**, one of them a
+regression introduced by this PR's migration. Both fixed and re-verified live.
+
+### Bug 1 (HIGH, regression) — prompt variables not substituted
+
+**Symptom:** translations came back as hallucinated/placeholder content (e.g. a
+fluent-but-unrelated article, or literal `[… title]`), not a translation of the
+source. **Root cause:** the publishing prompt template uses capitalized
+placeholders `{{Title}}` / `{{Content}}`, but the new adapter's `source_fields/2`
+returned lowercase `"title"` / `"content"` keys. Core feeds those keys straight
+into `PhoenixKitAI.Prompt.render`, whose substitution is **case-sensitive**
+(`get_variable_value` tries the string key then the atom key, nothing else;
+unmatched `{{…}}` is left literal). So `{{Title}}`/`{{Content}}` never rendered,
+the model received the template with empty/literal placeholders, and made
+something up. The retired `TranslatePostWorker` fed capitalized `"Title"`/
+`"Content"` (verified in git `a446178^`); the migration to the generic pipeline
+dropped that casing — the keys now drive both substitution **and** response
+parsing, so they must match the prompt.
+
+**Fix:** `source_fields/2` emits `"Title"` / `"Content"`; `build_params/3` reads
+them back under the same casing (DB params stay lowercase `title`/`content`).
+(`lib/phoenix_kit_publishing/ai_translatable.ex`) Verified live: re-translating
+en-US → ru now yields a genuine translation — title "Демонстрация рендеринга
+Markdown" (= "Markdown Rendering Demo"), body translating the actual source,
+slug `demonstratsiya-renderinga-markdown`.
+
+### Bug 2 (latent) — `source_content_blank?/1` checked the viewed language
+
+On a non-primary page it read `socket.assigns[:current_language]` (e.g. an empty
+`ru` buffer) instead of the primary, so the confirmation modal falsely warned
+"The source content is empty" while the real source (en-US) had content. Same
+`current_language`-as-source bug-class Codex flagged in `do_enqueue_translation`,
+in a sibling warning helper the Batch-2 fix missed. Now uses
+`source_language_for_translation/1` (the primary) consistently. Verified live:
+the false warning is gone; only the legitimate "will overwrite" warning remains.
+(`web/editor/translation.ex`)
+
+### Also confirmed working in the same live run
+- Enqueued job args: `source_lang=en-US` (the **primary**, not the viewed `ru`)
+  — the Batch-2 source fix, end-to-end.
+- `url_slug` generated **locally** as a Cyrillic→Latin transliteration via the
+  slug engine, written to the correct version; editor LiveView live-updates via
+  PubSub on completion.
+- A misbehaving reasoning endpoint that dumped chain-of-thought into the title
+  (>500 chars) was **discarded cleanly** by the content changeset — no
+  partial/corrupt write.
+
 ## Tests added (Batch — 2026-06-07)
 
 - `test/phoenix_kit_publishing/ai_translatable_test.exs` (new) — the four
@@ -66,6 +117,13 @@ Codex flagged two genuine HIGH bugs in the AI-translation path (both verified):
   `publishing_slug_style` setting.
 - `translation_manager_bulk_test.exs` (added earlier in the PR) — pins
   `build_bulk_translation_params/2`.
+- `editor_translation_test.exs` (new, Batch 4) — `source_content_blank?/1`
+  reads the primary language as source on a non-primary page (regression guard
+  for Batch-4 Bug 2), and uses the live buffer when viewing the primary.
+- `ai_translatable_test.exs` (Batch 4) — `source_fields/2` pins the exact key
+  set `["Content", "Title"]` (capitalized), the regression guard for Batch-4
+  Bug 1: a lowercase key would leave the prompt placeholders unrendered. The
+  `put_translation/4` tests feed `"Title"`/`"Content"` accordingly.
 - `ai_translatable_test.exs` — added a slug-conflict test: when another post
   already owns the generated slug in the same group+language, the new
   translation's `url_slug` is omitted and falls back to the post's default slug
@@ -130,12 +188,13 @@ runnable in the review sandbox (no `psql`); precommit was the gate.
 
 | File | Change |
 |------|--------|
-| `lib/phoenix_kit_publishing/ai_translatable.ex` | url_slug uniqueness guard; `:post_slug` on struct; `with` simplification; dead `|| %{}` drop (Batch 3) |
+| `lib/phoenix_kit_publishing/ai_translatable.ex` | url_slug uniqueness guard; `:post_slug` on struct; `with` simplification; dead `\|\| %{}` drop; **`source_fields`/`build_params` field keys `Title`/`Content` to match the prompt placeholders (Batch 4 — substitution regression fix)** |
 | `lib/phoenix_kit_publishing/web/editor.ex` | `maxlength="200"` on url_slug input; style-aware `pattern` (Batch 3) |
 | `lib/phoenix_kit_publishing/web/editor/translation.ex` | source lang = primary (Batch 2 + Batch 3 `source_content_blank?`); `@translate_worker` ref (Batch 3) |
 | `lib/phoenix_kit_publishing/slug_helpers.ex` | `html_input_pattern/0` (Batch 3) |
-| `test/phoenix_kit_publishing/ai_translatable_test.exs` | new — 7 adapter tests (incl. slug-conflict) |
+| `test/phoenix_kit_publishing/ai_translatable_test.exs` | new — 7 adapter tests (incl. slug-conflict); pins `source_fields` key casing `["Content","Title"]` (Batch 4) |
 | `test/phoenix_kit_publishing/slug_helpers_test.exs` | +6 slug-engine / style tests; +`html_input_pattern/0` (Batch 3) |
+| `test/phoenix_kit_publishing/editor_translation_test.exs` | new — `source_content_blank?/1` source-language regression (Batch 4) |
 
 ## Verification
 

--- a/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
@@ -116,6 +116,37 @@ the false warning is gone; only the legitimate "will overwrite" warning remains.
   (>500 chars) was **discarded cleanly** by the content changeset — no
   partial/corrupt write.
 
+## Codex re-review (Batch 4, 2026-06-07) — 3 findings, all verified
+
+- **F3 (Low) — FIXED.** The programmatic bulk API (`build_bulk_translation_params/2`)
+  resolved the prompt/endpoint with a bare `Settings.get_setting/1` and **no slug
+  fallback**, while the editor used the richer `get_default_ai_prompt_uuid/0`
+  (setting → slug). So with the setting unset but the default prompt present,
+  the bulk API enqueued `prompt_uuid: nil` and failed. Fixed by moving the
+  canonical resolvers (`default_endpoint_uuid/0`, `default_prompt_uuid/0`,
+  `default_prompt_exists?/0`) **into `TranslationManager` (domain)** — the
+  editor now delegates to them, so both paths share one source of truth and
+  can't drift. (`translation_manager.ex`, `web/editor/translation.ex`)
+- **F1 (Medium) — SURFACED (core-contract limitation).** The generic
+  `Translatable.fetch/2` contract is `(resource_type, resource_uuid)` — there is
+  **no version dimension**, so the editor's `current_version` cannot be threaded
+  into the job. `fetch/2` re-resolves the active version; on a published-v1 +
+  draft-v2 post, translating while viewing the draft targets v1. Read==write
+  stays consistent (no corruption) — it just always targets the active version.
+  Fixing this needs a core change (carry a version/opaque-key through the job to
+  `fetch/2`). **For Max:** want the generic pipeline to support a version/scope
+  dimension, or should publishing always translate the active version (and the
+  editor reflect that)? Matches the documented v1/v2 residual below.
+- **F2 (Medium) — SURFACED + dev fixed.** A "Translate Publishing Posts" prompt
+  generated **before** the lowercase standardization still carries
+  `{{Title}}/{{Content}}`; `default_prompt_exists?/0` only checks slug presence,
+  so the UI hides "Generate Default Prompt" and the stale row keeps hallucinating
+  (it predates the fail-closed instruction). The dev DB prompt was lowercased in
+  place. **For Max:** pre-release, so no production installs — but if any prompt
+  predates this, regenerate it. A guided "your prompt is stale, regenerate?"
+  affordance would be the durable fix (deliberately not auto-rewriting a
+  possibly-customized prompt).
+
 ## Tests added (Batch — 2026-06-07)
 
 - `test/phoenix_kit_publishing/ai_translatable_test.exs` (new) — the four

--- a/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
@@ -186,6 +186,33 @@ adapter unit test pins scope "1"→v1 / "2"→v2 on a two-version post.
 CI stays red (same hold as the rest of this PR). Pin left at `~> 1.7.132`; Max
 cuts the core release + the pin bump.
 
+## Codex re-review of F1 (Batch 5, 2026-06-07) — 3 findings
+
+- **F-A (Medium) — FIXED.** Nil-scope jobs (the programmatic bulk API; legacy
+  pre-upgrade jobs) write the active version, but the editor filters events by a
+  concrete version string (`"1"`), so `nil ≠ "1"` meant an open editor on the
+  active version ignored bulk-job completion/failure events and didn't restore
+  in-flight state. Fix: the bulk builder now resolves the post's **active
+  version number** and passes it as `resource_scope` (instead of nil), so it
+  matches an editor on that version. Truly-legacy nil-scope jobs remain
+  unmatched but drain within minutes. (`translation_manager.ex`)
+- **F-C (Low) — FIXED (core).** Core AI audit entries omitted the scope, so logs
+  couldn't tell v1 from v2 translation work. `TranslateWorker.log_added/2` now
+  includes `resource_scope` in metadata when present (unversioned resources'
+  entries unchanged). (core `translate_worker.ex`)
+- **F-B (Low/Med) — SURFACED.** `:translation_created` (publishing's per-language
+  content event) is version-blind — `broadcast_translation_created/3` drops the
+  version and editors handle it by uuid only, so a v1 new-language event triggers
+  a (harmless) refresh in a v2 editor. Not fixed here: that event is **shared
+  with the manual add-language flow**, so threading version through it has a
+  wider blast radius than the spurious-refresh payoff. **For Max:** worth a
+  follow-up if cross-version editor refreshes become noticeable.
+
+Codex confirmed: nil-scope dedup `IS NULL` is correct; string/integer
+canonicalization is consistent (publishing `to_string`, core normalizes ints,
+`parse_scope` accepts both); `fetch/3` optionality + `fetch/2` fallback keep
+catalogue/projects back-compatible.
+
 ## Tests added (Batch — 2026-06-07)
 
 - `test/phoenix_kit_publishing/ai_translatable_test.exs` (new) — the four

--- a/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
@@ -76,12 +76,24 @@ something up. The retired `TranslatePostWorker` fed capitalized `"Title"`/
 dropped that casing — the keys now drive both substitution **and** response
 parsing, so they must match the prompt.
 
-**Fix:** `source_fields/2` emits `"Title"` / `"Content"`; `build_params/3` reads
-them back under the same casing (DB params stay lowercase `title`/`content`).
-(`lib/phoenix_kit_publishing/ai_translatable.ex`) Verified live: re-translating
-en-US → ru now yields a genuine translation — title "Демонстрация рендеринга
-Markdown" (= "Markdown Rendering Demo"), body translating the actual source,
-slug `demonstratsiya-renderinga-markdown`.
+**Fix (standardized to the ecosystem convention):** rather than match
+publishing's bespoke capitalized prompt, we aligned publishing with the
+catalogue/projects convention — **lowercase** field keys throughout.
+`source_fields/2` emits `"title"`/`"content"`, `build_params/3` reads them back
+(DB params were already lowercase), and the shipped default prompt
+(`default_prompt_content/0`) now uses `{{title}}`/`{{content}}` plus the generic
+*"skip a value that is still a literal `{{placeholder}}`"* instruction, so a
+future binding mismatch **fails closed** (field skipped → clean missing-marker
+error) instead of hallucinating. Verified live (lowercase path, fresh job): title
+"Демонстрация рендеринга Markdown" (= "Markdown Rendering Demo"), body
+translating the actual source, slug `demonstratsiya-renderinga-markdown`.
+(`ai_translatable.ex`, `web/editor/translation.ex`)
+
+**Existing installs:** a previously-generated "Translate Publishing Posts"
+prompt still carries the old `{{Title}}`/`{{Content}}` placeholders and must be
+regenerated (or its placeholders lowercased) to work with the standardized
+adapter. The dev DB prompt was updated in place. **Surfaced to Max** — pre-release,
+so no production installs are affected yet.
 
 ### Bug 2 (latent) — `source_content_blank?/1` checked the viewed language
 
@@ -121,9 +133,14 @@ the false warning is gone; only the legitimate "will overwrite" warning remains.
   reads the primary language as source on a non-primary page (regression guard
   for Batch-4 Bug 2), and uses the live buffer when viewing the primary.
 - `ai_translatable_test.exs` (Batch 4) — `source_fields/2` pins the exact key
-  set `["Content", "Title"]` (capitalized), the regression guard for Batch-4
-  Bug 1: a lowercase key would leave the prompt placeholders unrendered. The
-  `put_translation/4` tests feed `"Title"`/`"Content"` accordingly.
+  set `["content", "title"]` (lowercase, matching the standardized prompt), the
+  regression guard for Batch-4 Bug 1: any casing drift leaves the prompt
+  placeholders unrendered.
+- `editor_translation_test.exs` (Batch 4) — a prompt↔adapter **contract test**:
+  extracts every `{{placeholder}}` from `default_prompt_content/0` (minus the
+  core-provided language slots) and asserts it equals the key set
+  `source_fields/2` binds. This is the guard that fails the moment the prompt
+  and adapter casing drift apart again.
 - `ai_translatable_test.exs` — added a slug-conflict test: when another post
   already owns the generated slug in the same group+language, the new
   translation's `url_slug` is omitted and falls back to the post's default slug

--- a/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
@@ -200,13 +200,15 @@ cuts the core release + the pin bump.
   couldn't tell v1 from v2 translation work. `TranslateWorker.log_added/2` now
   includes `resource_scope` in metadata when present (unversioned resources'
   entries unchanged). (core `translate_worker.ex`)
-- **F-B (Low/Med) — SURFACED.** `:translation_created` (publishing's per-language
-  content event) is version-blind — `broadcast_translation_created/3` drops the
-  version and editors handle it by uuid only, so a v1 new-language event triggers
-  a (harmless) refresh in a v2 editor. Not fixed here: that event is **shared
-  with the manual add-language flow**, so threading version through it has a
-  wider blast radius than the spurious-refresh payoff. **For Max:** worth a
-  follow-up if cross-version editor refreshes become noticeable.
+- **F-B (Low/Med) — FIXED.** `:translation_created` (publishing's per-language
+  content event) was version-blind — every editor for the post refreshed on any
+  version's new language. Threaded the version through:
+  `broadcast_translation_created/4` carries the version string (default nil =
+  legacy behavior), `add_language_to_post` passes the row's version, and the
+  editor handler refreshes only when it matches `current_version_scope/1`. This
+  covers BOTH the AI path and the shared manual add-language flow (both go
+  through `add_language_to_post`), so it was safe to thread without a separate
+  blast radius. (`pubsub.ex`, `translation_manager.ex`, `web/editor.ex`)
 
 Codex confirmed: nil-scope dedup `IS NULL` is correct; string/integer
 canonicalization is consistent (publishing `to_string`, core normalizes ints,

--- a/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/22-editor-ux-slug-ai-translation/FOLLOW_UP.md
@@ -147,6 +147,45 @@ the false warning is gone; only the legitimate "will overwrite" warning remains.
   affordance would be the durable fix (deliberately not auto-rewriting a
   possibly-customized prompt).
 
+## Decisions implemented (Batch 5, 2026-06-07) — F1 + F2
+
+Both Codex re-review mediums were turned into decisions (planning-capper
+quick-verify on F1) and implemented.
+
+### F2 — regenerate affordance for stale prompts (publishing-only)
+`Translation.default_translation_prompt_stale?/0` + `regenerate_default_translation_prompt/0`
+(updates the row in place via `PhoenixKitAI.update_prompt/3`); editor shows a
+"Regenerate Default Prompt" button when a stale (pre-lowercase) prompt exists.
+Live-verified: re-staling the dev prompt surfaced the button; clicking it
+repaired the row.
+
+### F1 — version scope through the generic pipeline (CORE + publishing)
+Chosen approach: thread an opaque `resource_scope` so a draft v2 translates
+independently of the active v1 (was: always the active version). Cross-repo:
+
+- **Core `phoenix_kit`** (commit on core `main`): optional `Translatable.fetch/3`;
+  `Translations` normalizes `resource_scope` (JSON-safe string|nil) and keys the
+  in-flight **dedup** on it; `TranslateWorker` threads it from args, dispatches
+  `fetch/3` when exported (guarded `Code.ensure_loaded?/1`) else `fetch/2`, and
+  adds it to lifecycle broadcast payloads. Backward-compatible — catalogue/projects
+  keep `fetch/2`; legacy unscoped jobs still run.
+- **Publishing**: `AITranslatable.fetch/3` (scope = version number; `fetch/2`
+  delegates with nil = active version); editor enqueue passes
+  `resource_scope = current_version`; the in-flight-restore query and the
+  `{:ai_translation,…}` + `{:translation_started,…}` handlers filter by scope so
+  a different-version editor ignores another version's progress/locks.
+
+Per the planning-capper, scope was threaded through the **full** job-identity
+surface (dedup + in-flight query + PubSub start payload + completion/fail
+filtering), not just enqueue. Live-verified: enqueuing from the v1 editor
+produced a job with `resource_scope="1"` that completed and wrote v1; the
+adapter unit test pins scope "1"→v1 / "2"→v2 on a two-version post.
+
+**Release gate (extends the existing one):** F1's publishing side needs core's
+`fetch/3` — i.e. the **next** core release after 1.7.132. Until then publishing
+CI stays red (same hold as the rest of this PR). Pin left at `~> 1.7.132`; Max
+cuts the core release + the pin bump.
+
 ## Tests added (Batch — 2026-06-07)
 
 - `test/phoenix_kit_publishing/ai_translatable_test.exs` (new) — the four

--- a/lib/phoenix_kit_publishing/ai_translatable.ex
+++ b/lib/phoenix_kit_publishing/ai_translatable.ex
@@ -18,10 +18,10 @@ defmodule PhoenixKitPublishing.AITranslatable do
 
   ## Fields
 
-  `source_fields/2` returns `%{"Title", "Content"}` read in the source
-  language — capitalized to match the `{{Title}}`/`{{Content}}` placeholders in
-  the publishing translation prompt (core's variable substitution is
-  case-sensitive). `put_translation/4` creates the target-language content row (via
+  `source_fields/2` returns `%{"title", "content"}` read in the source
+  language — lowercase to match the `{{title}}`/`{{content}}` placeholders in
+  the publishing translation prompt, the same convention as the catalogue and
+  projects adapters (core's variable substitution is case-sensitive). `put_translation/4` creates the target-language content row (via
   `add_language_to_post` when absent) and writes the translated title/content,
   **generating the per-language `url_slug` locally** from the translated title
   via `SlugHelpers.slugify/1`. That honors the configured slug style and avoids
@@ -89,16 +89,17 @@ defmodule PhoenixKitPublishing.AITranslatable do
   def source_fields(%__MODULE__{} = resource, source_lang) do
     case Publishing.read_post_by_uuid(resource.post_uuid, source_lang, resource.version) do
       {:ok, post} ->
-        # Keys are capitalized ("Title"/"Content") to match the placeholders in
-        # the publishing translation prompt ({{Title}}/{{Content}}). Core's
-        # prompt-variable substitution is case-SENSITIVE
-        # (PhoenixKitAI.Prompt.get_variable_value), and the same field keys
-        # drive response parsing (markers are upcased either way), so the casing
-        # must line up with the prompt or {{Title}}/{{Content}} render literally
-        # and the model hallucinates instead of translating.
+        # Lowercase keys ("title"/"content") match the prompt's {{title}}/
+        # {{content}} placeholders — the same convention as the catalogue and
+        # projects adapters. Core's prompt substitution is case-SENSITIVE
+        # (PhoenixKitAI.Prompt.get_variable_value) and these keys also drive
+        # response parsing (markers are upcased either way), so they must line
+        # up with the prompt placeholders or the model gets a literal {{title}}
+        # and hallucinates. editor_translation_test.exs pins the default
+        # prompt's placeholders against these keys.
         %{}
-        |> put_nonempty("Title", extract_title(post))
-        |> put_nonempty("Content", post.content || "")
+        |> put_nonempty("title", extract_title(post))
+        |> put_nonempty("content", post.content || "")
 
       _ ->
         %{}
@@ -156,13 +157,13 @@ defmodule PhoenixKitPublishing.AITranslatable do
 
   defp build_params(fields, resource, target_lang) do
     # `fields` comes back from core's parser keyed by the SAME names
-    # source_fields/2 emitted ("Title"/"Content"); the DB params are the
-    # lowercase content-schema fields.
-    title = Map.get(fields, "Title")
+    # source_fields/2 emitted ("title"/"content"), which are already the
+    # lowercase content-schema field names.
+    title = Map.get(fields, "title")
 
     %{}
     |> maybe_put("title", title)
-    |> maybe_put("content", Map.get(fields, "Content"))
+    |> maybe_put("content", Map.get(fields, "content"))
     |> maybe_put_slug(title, resource, target_lang)
   end
 

--- a/lib/phoenix_kit_publishing/ai_translatable.ex
+++ b/lib/phoenix_kit_publishing/ai_translatable.ex
@@ -1,8 +1,8 @@
 defmodule PhoenixKitPublishing.AITranslatable do
   @moduledoc """
-  `PhoenixKit.Modules.AI.Translatable` adapter for publishing posts — the
+  `PhoenixKitAI.Translatable` adapter for publishing posts — the
   per-module hook into core's generic AI-translation pipeline
-  (`PhoenixKit.Modules.AI.{Translations,TranslateWorker}`).
+  (`PhoenixKitAI.{Translations,TranslateWorker}`).
 
   Replaces the bespoke `Workers.TranslatePostWorker`, which translated every
   language **sequentially in a single Oban job**. `Translations.enqueue_all_missing/2`
@@ -42,7 +42,7 @@ defmodule PhoenixKitPublishing.AITranslatable do
   publishing's own `:translation_created` via `add_language_to_post`.
   """
 
-  @behaviour PhoenixKit.Modules.AI.Translatable
+  @behaviour PhoenixKitAI.Translatable
 
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.Constants

--- a/lib/phoenix_kit_publishing/ai_translatable.ex
+++ b/lib/phoenix_kit_publishing/ai_translatable.ex
@@ -18,8 +18,10 @@ defmodule PhoenixKitPublishing.AITranslatable do
 
   ## Fields
 
-  `source_fields/2` returns `%{"title", "content"}` read in the source
-  language. `put_translation/4` creates the target-language content row (via
+  `source_fields/2` returns `%{"Title", "Content"}` read in the source
+  language — capitalized to match the `{{Title}}`/`{{Content}}` placeholders in
+  the publishing translation prompt (core's variable substitution is
+  case-sensitive). `put_translation/4` creates the target-language content row (via
   `add_language_to_post` when absent) and writes the translated title/content,
   **generating the per-language `url_slug` locally** from the translated title
   via `SlugHelpers.slugify/1`. That honors the configured slug style and avoids
@@ -87,9 +89,16 @@ defmodule PhoenixKitPublishing.AITranslatable do
   def source_fields(%__MODULE__{} = resource, source_lang) do
     case Publishing.read_post_by_uuid(resource.post_uuid, source_lang, resource.version) do
       {:ok, post} ->
+        # Keys are capitalized ("Title"/"Content") to match the placeholders in
+        # the publishing translation prompt ({{Title}}/{{Content}}). Core's
+        # prompt-variable substitution is case-SENSITIVE
+        # (PhoenixKitAI.Prompt.get_variable_value), and the same field keys
+        # drive response parsing (markers are upcased either way), so the casing
+        # must line up with the prompt or {{Title}}/{{Content}} render literally
+        # and the model hallucinates instead of translating.
         %{}
-        |> put_nonempty("title", extract_title(post))
-        |> put_nonempty("content", post.content || "")
+        |> put_nonempty("Title", extract_title(post))
+        |> put_nonempty("Content", post.content || "")
 
       _ ->
         %{}
@@ -146,11 +155,14 @@ defmodule PhoenixKitPublishing.AITranslatable do
   end
 
   defp build_params(fields, resource, target_lang) do
-    title = Map.get(fields, "title")
+    # `fields` comes back from core's parser keyed by the SAME names
+    # source_fields/2 emitted ("Title"/"Content"); the DB params are the
+    # lowercase content-schema fields.
+    title = Map.get(fields, "Title")
 
     %{}
     |> maybe_put("title", title)
-    |> maybe_put("content", Map.get(fields, "content"))
+    |> maybe_put("content", Map.get(fields, "Content"))
     |> maybe_put_slug(title, resource, target_lang)
   end
 

--- a/lib/phoenix_kit_publishing/ai_translatable.ex
+++ b/lib/phoenix_kit_publishing/ai_translatable.ex
@@ -1,7 +1,7 @@
 defmodule PhoenixKitPublishing.AITranslatable do
   @moduledoc """
   `PhoenixKitAI.Translatable` adapter for publishing posts — the
-  per-module hook into core's generic AI-translation pipeline
+  per-module hook into PhoenixKitAI's generic AI-translation pipeline
   (`PhoenixKitAI.{Translations,TranslateWorker}`).
 
   Replaces the bespoke `Workers.TranslatePostWorker`, which translated every
@@ -13,15 +13,15 @@ defmodule PhoenixKitPublishing.AITranslatable do
   ## Resource identity
 
   `resource_type` is `"publishing_post"`; `resource_uuid` is the post's uuid
-  (core validates it as a real UUID). Translations target the post's **active
-  version** — the version the editor normally works on.
+  (PhoenixKitAI validates it as a real UUID). Translations target the post's
+  **active version** — the version the editor normally works on.
 
   ## Fields
 
   `source_fields/2` returns `%{"title", "content"}` read in the source
   language — lowercase to match the `{{title}}`/`{{content}}` placeholders in
   the publishing translation prompt, the same convention as the catalogue and
-  projects adapters (core's variable substitution is case-sensitive). `put_translation/4` creates the target-language content row (via
+  projects adapters (PhoenixKitAI's variable substitution is case-sensitive). `put_translation/4` creates the target-language content row (via
   `add_language_to_post` when absent) and writes the translated title/content,
   **generating the per-language `url_slug` locally** from the translated title
   via `SlugHelpers.slugify/1`. That honors the configured slug style and avoids
@@ -36,7 +36,7 @@ defmodule PhoenixKitPublishing.AITranslatable do
 
   ## Events
 
-  `pubsub_topics/1` returns the post's translations topic, so core's
+  `pubsub_topics/1` returns the post's translations topic, so PhoenixKitAI's
   `{:ai_translation, …}` lifecycle events reach the editor LiveView (already
   subscribed to that topic). Per-language content creation also emits
   publishing's own `:translation_created` via `add_language_to_post`.

--- a/lib/phoenix_kit_publishing/ai_translatable.ex
+++ b/lib/phoenix_kit_publishing/ai_translatable.ex
@@ -64,18 +64,27 @@ defmodule PhoenixKitPublishing.AITranslatable do
         }
 
   @impl true
-  def fetch(@resource_type, post_uuid) when is_binary(post_uuid) do
-    case Publishing.read_post_by_uuid(post_uuid, LanguageHelpers.get_primary_language()) do
+  # Required arity — delegates with a nil scope, i.e. the post's active version
+  # (the historical fetch/2 behavior).
+  def fetch(resource_type, post_uuid), do: fetch(resource_type, post_uuid, nil)
+
+  @impl true
+  def fetch(@resource_type, post_uuid, scope) when is_binary(post_uuid) do
+    # `scope` is the version number (as a string from the Oban args) the editor
+    # was on; nil → active version. Pin the resolved version and thread it
+    # through the read (source_fields) and the write (ensure_language_row) so a
+    # published post with a newer draft can't read one version and write another
+    # — and so translating a draft targets THAT draft, not the active version.
+    version = parse_scope(scope)
+
+    case Publishing.read_post_by_uuid(post_uuid, LanguageHelpers.get_primary_language(), version) do
       {:ok, post} ->
-        # Pin the version we resolved here and thread it through both the read
-        # (source_fields) and the write (ensure_language_row), so a published
-        # post with a newer draft can't read one version and write another.
         {:ok,
          %__MODULE__{
            post_uuid: post_uuid,
            group_slug: post.group,
            post_slug: post.slug,
-           version: Map.get(post, :version)
+           version: version || Map.get(post, :version)
          }}
 
       _ ->
@@ -83,7 +92,20 @@ defmodule PhoenixKitPublishing.AITranslatable do
     end
   end
 
-  def fetch(other, _uuid), do: {:error, {:unknown_resource_type, other}}
+  def fetch(other, _uuid, _scope), do: {:error, {:unknown_resource_type, other}}
+
+  # resource_scope carries the version number as a decimal string (or nil).
+  defp parse_scope(nil), do: nil
+  defp parse_scope(v) when is_integer(v), do: v
+
+  defp parse_scope(v) when is_binary(v) do
+    case Integer.parse(v) do
+      {n, ""} -> n
+      _ -> nil
+    end
+  end
+
+  defp parse_scope(_), do: nil
 
   @impl true
   def source_fields(%__MODULE__{} = resource, source_lang) do

--- a/lib/phoenix_kit_publishing/publishing.ex
+++ b/lib/phoenix_kit_publishing/publishing.ex
@@ -219,7 +219,6 @@ defmodule PhoenixKit.Modules.Publishing do
     settings_call(:get_boolean_setting, [@publishing_enabled_key, false])
   end
 
-  @impl PhoenixKit.Module
   @spec ai_translatables() :: [{String.t(), module()}]
   def ai_translatables do
     [{PhoenixKitPublishing.AITranslatable.resource_type(), PhoenixKitPublishing.AITranslatable}]

--- a/lib/phoenix_kit_publishing/pubsub.ex
+++ b/lib/phoenix_kit_publishing/pubsub.ex
@@ -442,9 +442,13 @@ defmodule PhoenixKit.Modules.Publishing.PubSub do
   Broadcasts that AI translation has started.
   Sent to both posts_topic (for group listing) and post_translations_topic (for editor).
   """
-  @spec broadcast_translation_started(String.t(), String.t(), [String.t()]) :: broadcast_result
-  def broadcast_translation_started(group_slug, post_slug, target_languages) do
-    payload = {:translation_started, group_slug, post_slug, target_languages}
+  @spec broadcast_translation_started(String.t(), String.t(), [String.t()], String.t() | nil) ::
+          broadcast_result
+  def broadcast_translation_started(group_slug, post_slug, target_languages, scope \\ nil) do
+    # `scope` (the version the jobs target) rides the editor payload so an editor
+    # viewing a different version ignores this start event — versions translate
+    # independently. The group-listing payload stays version-agnostic.
+    payload = {:translation_started, group_slug, post_slug, target_languages, scope}
 
     # Broadcast to group listing
     Manager.broadcast(

--- a/lib/phoenix_kit_publishing/pubsub.ex
+++ b/lib/phoenix_kit_publishing/pubsub.ex
@@ -285,12 +285,18 @@ defmodule PhoenixKit.Modules.Publishing.PubSub do
 
   @doc """
   Broadcasts that a new translation was created for a post.
+
+  `version` (the version-number string the language row was added to, or nil)
+  rides the payload so an editor viewing a different version ignores it —
+  versions hold independent per-language content. nil keeps the legacy
+  version-agnostic behavior.
   """
-  @spec broadcast_translation_created(String.t(), String.t(), String.t()) :: broadcast_result
-  def broadcast_translation_created(group_slug, post_slug, language) do
+  @spec broadcast_translation_created(String.t(), String.t(), String.t(), String.t() | nil) ::
+          broadcast_result
+  def broadcast_translation_created(group_slug, post_slug, language, version \\ nil) do
     Manager.broadcast(
       post_translations_topic(group_slug, post_slug),
-      {:translation_created, group_slug, post_slug, language}
+      {:translation_created, group_slug, post_slug, language, version}
     )
   end
 

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -21,6 +21,69 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
   alias PhoenixKit.Settings
   alias PhoenixKitPublishing.AITranslatable
 
+  # Slug of the publishing-specific default translation prompt. Canonical here
+  # (domain) so the editor LiveView and the programmatic bulk API resolve the
+  # default endpoint/prompt the same way — the editor delegates to these.
+  @translation_prompt_slug "translate-publishing-posts"
+
+  @doc """
+  Resolves the default AI endpoint UUID for publishing translation.
+
+  Reads the `publishing_translation_endpoint_uuid` setting; `nil`/`""` → `nil`.
+  """
+  @spec default_endpoint_uuid() :: String.t() | nil
+  def default_endpoint_uuid do
+    case Settings.get_setting("publishing_translation_endpoint_uuid") do
+      nil -> nil
+      "" -> nil
+      id -> id
+    end
+  end
+
+  @doc """
+  Resolves the default AI prompt UUID for publishing translation.
+
+  Prefers the `publishing_translation_prompt_uuid` setting, then falls back to
+  the prompt with slug `#{@translation_prompt_slug}`. Both the editor and the
+  bulk API use this so they can't drift (the bulk API previously skipped the
+  slug fallback and could enqueue a `nil` prompt).
+  """
+  @spec default_prompt_uuid() :: String.t() | nil
+  def default_prompt_uuid do
+    case Settings.get_setting("publishing_translation_prompt_uuid") do
+      nil -> prompt_uuid_by_slug()
+      "" -> prompt_uuid_by_slug()
+      id -> id
+    end
+  end
+
+  @doc "Whether the publishing default translation prompt exists (by slug)."
+  @spec default_prompt_exists?() :: boolean()
+  def default_prompt_exists? do
+    ai_available?() and PhoenixKitAI.get_prompt_by_slug(@translation_prompt_slug) != nil
+  end
+
+  @doc "The slug of the publishing default translation prompt."
+  @spec translation_prompt_slug() :: String.t()
+  def translation_prompt_slug, do: @translation_prompt_slug
+
+  defp prompt_uuid_by_slug do
+    if ai_available?() do
+      case PhoenixKitAI.get_prompt_by_slug(@translation_prompt_slug) do
+        nil -> nil
+        prompt -> prompt.uuid
+      end
+    else
+      nil
+    end
+  end
+
+  # PhoenixKitAI is an optional plugin — guard the reference so this domain
+  # module compiles and runs when the plugin is absent.
+  defp ai_available? do
+    Code.ensure_loaded?(PhoenixKitAI) and PhoenixKitAI.enabled?()
+  end
+
   @doc """
   Adds a new language translation to an existing post.
 
@@ -338,10 +401,8 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
       %{
         resource_type: AITranslatable.resource_type(),
         resource_uuid: post_uuid,
-        endpoint_uuid:
-          opts[:endpoint_uuid] || Settings.get_setting("publishing_translation_endpoint_uuid"),
-        prompt_uuid:
-          opts[:prompt_uuid] || Settings.get_setting("publishing_translation_prompt_uuid"),
+        endpoint_uuid: opts[:endpoint_uuid] || default_endpoint_uuid(),
+        prompt_uuid: opts[:prompt_uuid] || default_prompt_uuid(),
         source_lang: source_lang
       }
       |> maybe_put_actor(opts[:user_uuid])

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -78,8 +78,8 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
     end
   end
 
-  # PhoenixKitAI is an optional plugin — guard the reference so this domain
-  # module compiles and runs when the plugin is absent.
+  # Guard the AI facade so callers degrade cleanly when the AI runtime is not
+  # installed, disabled, or not fully started.
   defp ai_available? do
     Code.ensure_loaded?(PhoenixKitAI) and PhoenixKitAI.enabled?()
   end
@@ -374,7 +374,7 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
 
   ## Returns
 
-  Delegates to core's generic pipeline, enqueuing one job per target language
+  Delegates to PhoenixKitAI's generic pipeline, enqueuing one job per target language
   (they run in parallel):
 
   - `{:ok, %{enqueued: n, conflicts: n, errors: [], in_flight: [lang]}}`
@@ -389,7 +389,7 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
   end
 
   @doc false
-  # Public for testing. Assembles core's generic-pipeline `base_params` and the
+  # Public for testing. Assembles PhoenixKitAI translation `base_params` and the
   # target-language list for `translate_post_to_all_languages/3`, resolving
   # defaults: source = primary language; targets = all enabled except source;
   # endpoint/prompt fall back to the publishing settings; actor is included only

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
 
   require Logger
 
-  alias PhoenixKitAI.Translations
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Modules.Publishing.ActivityLog
   alias PhoenixKit.Modules.Publishing.Constants
@@ -19,6 +18,7 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
   alias PhoenixKit.Modules.Publishing.Shared
   alias PhoenixKit.Modules.Publishing.StaleFixer
   alias PhoenixKit.Settings
+  alias PhoenixKitAI.Translations
   alias PhoenixKitPublishing.AITranslatable
 
   # Slug of the publishing-specific default translation prompt. Canonical here

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -403,7 +403,13 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
         resource_uuid: post_uuid,
         endpoint_uuid: opts[:endpoint_uuid] || default_endpoint_uuid(),
         prompt_uuid: opts[:prompt_uuid] || default_prompt_uuid(),
-        source_lang: source_lang
+        source_lang: source_lang,
+        # Scope to the active version's number (not nil) so an editor open on
+        # that version still matches the lifecycle events — the editor always
+        # filters by a concrete version string. `opts[:resource_scope]` lets a
+        # caller target a specific version; otherwise the active version, or nil
+        # when it can't be resolved (fetch/3 falls back to active either way).
+        resource_scope: opts[:resource_scope] || active_version_scope(post_uuid)
       }
       |> maybe_put_actor(opts[:user_uuid])
 
@@ -412,4 +418,16 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
 
   defp maybe_put_actor(params, nil), do: params
   defp maybe_put_actor(params, actor_uuid), do: Map.put(params, :actor_uuid, actor_uuid)
+
+  # The post's active version number as a string, matching the editor's scope
+  # convention. nil (→ active via fetch/3) when there's no active version or the
+  # lookup fails.
+  defp active_version_scope(post_uuid) do
+    case DBStorage.get_post_by_uuid(post_uuid, [:active_version]) do
+      %{active_version: %{version_number: n}} when is_integer(n) -> Integer.to_string(n)
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
 end

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -106,7 +106,12 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
       broadcast_id = new_post.uuid
 
       if broadcast_id do
-        PublishingPubSub.broadcast_translation_created(group_slug, broadcast_id, language_code)
+        PublishingPubSub.broadcast_translation_created(
+          group_slug,
+          broadcast_id,
+          language_code,
+          content_version_scope(new_post)
+        )
       end
 
       ActivityLog.log_manual(
@@ -418,6 +423,15 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
 
   defp maybe_put_actor(params, nil), do: params
   defp maybe_put_actor(params, actor_uuid), do: Map.put(params, :actor_uuid, actor_uuid)
+
+  # The version a read-back post map sits on, as the string the editor matches
+  # translation events against (mirrors the editor's current_version scope).
+  defp content_version_scope(post) do
+    case Map.get(post, :version) do
+      nil -> nil
+      version -> to_string(version)
+    end
+  end
 
   # The post's active version number as a string, matching the editor's scope
   # convention. nil (→ active via fetch/3) when there's no active version or the

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -7,7 +7,7 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
 
   require Logger
 
-  alias PhoenixKit.Modules.AI.Translations
+  alias PhoenixKitAI.Translations
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Modules.Publishing.ActivityLog
   alias PhoenixKit.Modules.Publishing.Constants

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -143,6 +143,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
       |> assign(:ai_prompts, Translation.list_ai_prompts())
       |> assign(:ai_selected_prompt_uuid, Translation.get_default_ai_prompt_uuid())
       |> assign(:ai_default_prompt_exists, Translation.default_translation_prompt_exists?())
+      |> assign(:ai_default_prompt_stale, Translation.default_translation_prompt_stale?())
       |> assign(:ai_translation_status, nil)
       |> assign(:ai_translation_progress, nil)
       |> assign(:ai_translation_total, nil)
@@ -761,6 +762,27 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
            socket,
            :error,
            gettext("Failed to create prompt. It may already exist.")
+         )}
+    end
+  end
+
+  def handle_event("regenerate_default_translation_prompt", _params, socket) do
+    case Translation.regenerate_default_translation_prompt() do
+      {:ok, prompt} ->
+        {:noreply,
+         socket
+         |> assign(:ai_prompts, Translation.list_ai_prompts())
+         |> assign(:ai_selected_prompt_uuid, prompt.uuid)
+         |> assign(:ai_default_prompt_exists, true)
+         |> assign(:ai_default_prompt_stale, false)
+         |> Phoenix.LiveView.put_flash(:info, gettext("Default translation prompt updated"))}
+
+      {:error, _changeset} ->
+        {:noreply,
+         Phoenix.LiveView.put_flash(
+           socket,
+           :error,
+           gettext("Failed to update the default prompt")
          )}
     end
   end
@@ -2160,6 +2182,17 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
                   >
                     <.icon name="hero-sparkles" class="w-3 h-3" />
                     {gettext("Generate Default Prompt")}
+                  </button>
+                <% end %>
+                <%= if @ai_default_prompt_exists and @ai_default_prompt_stale do %>
+                  <button
+                    type="button"
+                    class="btn btn-warning btn-outline btn-xs gap-1"
+                    phx-click="regenerate_default_translation_prompt"
+                    title={gettext("This prompt predates the current format and may mistranslate. Click to update it.")}
+                  >
+                    <.icon name="hero-arrow-path" class="w-3 h-3" />
+                    {gettext("Regenerate Default Prompt")}
                   </button>
                 <% end %>
               </div>

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -2141,11 +2141,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
             <p class="text-sm text-base-content/70">
               <%= if @current_language == @default_language do %>
                 {gettext(
-                  "Automatically translate this post to other languages using AI. The translation will be queued as a background job."
+                  "Automatically translate this post to other languages using AI. Each translation runs as a background job — you can keep editing while it finishes, or safely leave this page."
                 )}
               <% else %>
                 {gettext(
-                  "Translate the %{source} post to %{target} using AI. The translation will be queued as a background job.",
+                  "Translate the %{source} post to %{target} using AI. It runs as a background job — you can keep editing while it finishes, or safely leave this page.",
                   source: @default_language_name,
                   target: @current_language_name
                 )}
@@ -2172,6 +2172,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
               >
                 {gettext("Manage Endpoints")}
               </.link>
+              <p class="flex items-start gap-1 text-xs text-base-content/60">
+                <.icon name="hero-information-circle" class="w-3.5 h-3.5 shrink-0 mt-px" />
+                <span>
+                  {gettext(
+                    "Reasoning (\"thinking\") models are slower and may return unstructured output — a standard model is recommended for translation."
+                  )}
+                </span>
+              </p>
             </div>
 
             <%!-- Prompt Selection --%>

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -1368,8 +1368,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   # the per-language content row refresh rides publishing's :translation_created.
   def handle_info({:ai_translation, _event, _payload}, socket), do: {:noreply, socket}
 
-  def handle_info({:translation_created, group_slug, post_identifier, language}, socket) do
-    if socket.assigns[:group_slug] == group_slug && post_matches?(socket, post_identifier) do
+  def handle_info({:translation_created, group_slug, post_identifier, language, version}, socket) do
+    # Only refresh when the new language landed on the version this editor is
+    # viewing — a different version's per-language content is independent.
+    if socket.assigns[:group_slug] == group_slug && post_matches?(socket, post_identifier) &&
+         version == current_version_scope(socket) do
       {:noreply, handle_translation_created_update(socket, language)}
     else
       {:noreply, socket}

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -1308,8 +1308,12 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   # Handle Info - Translation Events
   # ============================================================================
 
-  def handle_info({:translation_started, group_slug, post_identifier, target_languages}, socket) do
-    if socket.assigns[:group_slug] == group_slug && post_matches?(socket, post_identifier) do
+  def handle_info(
+        {:translation_started, group_slug, post_identifier, target_languages, scope},
+        socket
+      ) do
+    if socket.assigns[:group_slug] == group_slug && post_matches?(socket, post_identifier) &&
+         scope == current_version_scope(socket) do
       current_lang = socket.assigns[:current_language]
       source_lang = source_language_for_translation(socket)
       should_lock = current_lang == source_lang or current_lang in target_languages
@@ -1332,10 +1336,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   # so we count completions toward the progress bar the :translation_started
   # event primed.
   def handle_info(
-        {:ai_translation, :translation_completed, %{resource_uuid: resource_uuid}},
+        {:ai_translation, :translation_completed, %{resource_uuid: resource_uuid} = payload},
         socket
       ) do
-    if ai_event_for_this_post?(socket, resource_uuid) do
+    if ai_event_for_this_post?(socket, resource_uuid, Map.get(payload, :resource_scope)) do
       {:noreply, socket |> bump_translation_progress() |> maybe_finalize_translation()}
     else
       {:noreply, socket}
@@ -1343,10 +1347,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   end
 
   def handle_info(
-        {:ai_translation, :translation_failed, %{resource_uuid: resource_uuid}},
+        {:ai_translation, :translation_failed, %{resource_uuid: resource_uuid} = payload},
         socket
       ) do
-    if ai_event_for_this_post?(socket, resource_uuid) do
+    if ai_event_for_this_post?(socket, resource_uuid, Map.get(payload, :resource_scope)) do
       socket =
         socket
         |> bump_translation_progress()
@@ -1529,10 +1533,24 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     post != nil && post[:uuid] == broadcast_id
   end
 
-  # Generic-pipeline events carry the post uuid as resource_uuid.
-  defp ai_event_for_this_post?(socket, resource_uuid) do
+  # Generic-pipeline events carry the post uuid as resource_uuid and the
+  # targeted version as resource_scope. Match BOTH so an editor viewing a
+  # different version of the same post ignores events for the other version.
+  defp ai_event_for_this_post?(socket, resource_uuid, resource_scope) do
     post = socket.assigns[:post]
-    is_binary(resource_uuid) and post != nil and post[:uuid] == resource_uuid
+
+    is_binary(resource_uuid) and post != nil and post[:uuid] == resource_uuid and
+      resource_scope == current_version_scope(socket)
+  end
+
+  # The version the editor is on, as the string the pipeline carries in
+  # `resource_scope` (nil → active version). Mirrors
+  # `Editor.Translation`'s enqueue scope so events match what was enqueued.
+  defp current_version_scope(socket) do
+    case socket.assigns[:current_version] do
+      nil -> nil
+      version -> to_string(version)
+    end
   end
 
   defp bump_translation_progress(socket) do

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -1331,7 +1331,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     end
   end
 
-  # Per-language success from core's generic pipeline. Each parallel job
+  # Per-language success from PhoenixKitAI's generic pipeline. Each parallel job
   # broadcasts on this post's translations topic (AITranslatable.pubsub_topics/1),
   # so we count completions toward the progress bar the :translation_started
   # event primed.

--- a/lib/phoenix_kit_publishing/web/editor/persistence.ex
+++ b/lib/phoenix_kit_publishing/web/editor/persistence.ex
@@ -559,12 +559,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   end
 
   defp handle_post_in_place_error(socket, :slug_already_exists) do
-    {:noreply,
-     Phoenix.LiveView.put_flash(
-       socket,
-       :error,
-       gettext("A post with that slug already exists")
-     )}
+    {:noreply, Phoenix.LiveView.put_flash(socket, :error, slug_taken_message(socket))}
   end
 
   defp handle_post_in_place_error(socket, reason) do
@@ -649,12 +644,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   end
 
   defp handle_post_update_error(socket, :slug_already_exists) do
-    {:noreply,
-     Phoenix.LiveView.put_flash(
-       socket,
-       :error,
-       gettext("A post with that slug already exists")
-     )}
+    {:noreply, Phoenix.LiveView.put_flash(socket, :error, slug_taken_message(socket))}
   end
 
   defp handle_post_update_error(socket, :title_required) do
@@ -670,6 +660,24 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
     post_id = socket.assigns[:post] && socket.assigns.post[:uuid]
     Logger.warning("[Publishing.Editor] Update failed for post #{post_id}: #{inspect(reason)}")
     {:noreply, Phoenix.LiveView.put_flash(socket, :error, gettext("Failed to save post"))}
+  end
+
+  # Clear, actionable message for a duplicate post slug. Names the offending
+  # slug (slugs are unique per group) so the user knows exactly what to change.
+  defp slug_taken_message(socket) do
+    slug =
+      socket.assigns |> Map.get(:form, %{}) |> Map.get("slug", "") |> to_string() |> String.trim()
+
+    if slug == "" do
+      gettext(
+        "That slug is already used by another post in this group. Please choose a different one."
+      )
+    else
+      gettext(
+        "The slug \"%{slug}\" is already used by another post in this group. Choose a different slug or change the title.",
+        slug: slug
+      )
+    end
   end
 
   defp slug_constraint_error?(changeset) do
@@ -695,14 +703,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   end
 
   defp handle_post_creation_error(socket, :slug_already_exists, _fallback_message) do
-    {:noreply,
-     Phoenix.LiveView.put_flash(
-       socket,
-       :error,
-       gettext(
-         "A post with that slug already exists. Please choose a different title or edit the slug manually."
-       )
-     )}
+    {:noreply, Phoenix.LiveView.put_flash(socket, :error, slug_taken_message(socket))}
   end
 
   defp handle_post_creation_error(socket, %Ecto.Changeset{} = changeset, fallback_message) do

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -101,46 +101,69 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   Returns {:ok, prompt} or {:error, changeset}.
   """
   def generate_default_translation_prompt do
-    attrs = %{
+    AI.create_prompt(%{
       name: "Translate Publishing Posts",
       description: "Default prompt for translating publishing posts between languages",
-      content: """
-      Translate the following content from {{SourceLanguage}} to {{TargetLanguage}}.
+      content: default_prompt_content()
+    })
+  end
 
-      RULES:
-      - Preserve the EXACT formatting of the original (headings, line breaks, spacing, etc.)
-      - If the original has a # heading, keep it. If it doesn't, don't add one.
-      - Preserve all Markdown formatting (bold, italic, links, code blocks, lists)
-      - Do NOT translate text inside code blocks or inline code
-      - Translate naturally and idiomatically
-      - Keep HTML tags and special syntax unchanged
+  @doc """
+  The shipped translation prompt template.
 
-      OUTPUT FORMAT - respond with ONLY this format, nothing else before or after:
+  The `{{title}}` / `{{content}}` placeholders are **lowercase on purpose** —
+  they must match, byte-for-byte, the keys `AITranslatable.source_fields/2`
+  binds (the same lowercase convention as the catalogue and projects prompts),
+  because core's prompt-variable substitution (`PhoenixKitAI.Prompt.render`) is
+  case-sensitive and silently leaves an unmatched `{{Var}}` literal in the
+  prompt. The defensive "skip a value that is still a literal placeholder"
+  rule makes a binding mismatch **fail closed** (the field is skipped, the job
+  fails cleanly on a missing marker) rather than producing a hallucinated
+  translation. `editor_translation_test.exs` pins the placeholder↔key invariant
+  so the two can't drift apart again. Exposed (not inlined) so that test can
+  read the template without writing a DB row.
+  """
+  @spec default_prompt_content() :: String.t()
+  def default_prompt_content do
+    """
+    Translate the following content from {{SourceLanguage}} to {{TargetLanguage}}.
 
-      ---TITLE---
-      [translated title - just the title text, no # symbol]
-      ---SLUG---
-      [url-friendly-slug-in-target-language]
-      ---CONTENT---
-      [translated content - preserve EXACT original formatting]
+    RULES:
+    - Preserve the EXACT formatting of the original (headings, line breaks, spacing, etc.)
+    - If the original has a # heading, keep it. If it doesn't, don't add one.
+    - Preserve all Markdown formatting (bold, italic, links, code blocks, lists)
+    - Do NOT translate text inside code blocks or inline code
+    - Translate naturally and idiomatically
+    - Keep HTML tags and special syntax unchanged
 
-      SLUG RULES:
-      - Lowercase letters only (a-z)
-      - Numbers allowed (0-9)
-      - Use hyphens (-) to separate words
-      - No spaces, accents, or special characters
-      - Keep it short and SEO-friendly
-      - Example: "getting-started" -> "primeros-pasos" (Spanish)
+    OUTPUT FORMAT - respond with ONLY this format, nothing else before or after:
 
-      === SOURCE CONTENT ===
+    ---TITLE---
+    [translated title - just the title text, no # symbol]
+    ---SLUG---
+    [url-friendly-slug-in-target-language]
+    ---CONTENT---
+    [translated content - preserve EXACT original formatting]
 
-      Title: {{Title}}
+    Skip any field whose source value below is missing, blank, or still a
+    literal placeholder (e.g. a value that looks like `{{title}}` means the
+    caller did not bind it) — do NOT emit its marker, and do NOT translate the
+    placeholder text itself.
 
-      {{Content}}
-      """
-    }
+    SLUG RULES:
+    - Lowercase letters only (a-z)
+    - Numbers allowed (0-9)
+    - Use hyphens (-) to separate words
+    - No spaces, accents, or special characters
+    - Keep it short and SEO-friendly
+    - Example: "getting-started" -> "primeros-pasos" (Spanish)
 
-    AI.create_prompt(attrs)
+    === SOURCE CONTENT ===
+
+    Title: {{title}}
+
+    {{content}}
+    """
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -277,7 +277,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
       endpoint_uuid: socket.assigns.ai_selected_endpoint_uuid,
       prompt_uuid: socket.assigns[:ai_selected_prompt_uuid],
       source_lang: source_language,
-      actor_uuid: user_uuid
+      actor_uuid: user_uuid,
+      # Translate the version the editor is on (a draft, not always the active
+      # one). Core threads this scope to AITranslatable.fetch/3 and keys job
+      # dedup on it, so v1 and v2 translate independently.
+      resource_scope: version_scope(socket)
     }
 
     case Translations.enqueue_all_missing(base_params, target_languages) do
@@ -285,11 +289,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
         {:noreply, translation_error_socket(socket)}
 
       {:ok, %{in_flight: in_flight}} ->
-        # Tell every editor session (incl. this one) to show progress + lock.
+        # Tell every editor session on THIS version (incl. this one) to show
+        # progress + lock; other-version editors ignore it (scope mismatch).
         PublishingPubSub.broadcast_translation_started(
           socket.assigns.group_slug,
           post.uuid,
-          in_flight
+          in_flight,
+          version_scope(socket)
         )
 
         {:noreply, translation_success_socket(socket, in_flight)}
@@ -407,6 +413,16 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   """
   def source_language_for_translation(_socket) do
     LanguageHelpers.get_primary_language()
+  end
+
+  # The version the editor is on, as the string `resource_scope` the core
+  # pipeline threads to `AITranslatable.fetch/3` and keys job dedup on. `nil`
+  # (no current version) → the post's active version.
+  defp version_scope(socket) do
+    case socket.assigns[:current_version] do
+      nil -> nil
+      version -> to_string(version)
+    end
   end
 
   defp check_source_language_editor(socket, warnings) do
@@ -579,7 +595,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
     post = socket.assigns[:post]
 
     if post && post[:uuid] do
-      case in_flight_translation_languages(post.uuid) do
+      case in_flight_translation_languages(post.uuid, version_scope(socket)) do
         [] ->
           socket
 
@@ -605,9 +621,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   end
 
   # Target languages with a non-terminal generic-pipeline translation job for
-  # any version of this post. Lets the editor restore the in-progress banner
-  # across a page refresh. Fails open (empty) on any query error.
-  defp in_flight_translation_languages(post_uuid) do
+  # THIS post AND THIS version (`scope`). Scoping by version matters now that
+  # each version translates independently — otherwise a v2 editor would restore
+  # v1's in-progress banner. `scope` is nil (active version) or the version
+  # string; a job matches when its stored `resource_scope` equals it (both nil
+  # ↔ unscoped/legacy jobs). Lets the editor restore the banner across a page
+  # refresh. Fails open (empty) on any query error.
+  defp in_flight_translation_languages(post_uuid, scope) do
     repo = PhoenixKit.RepoHelper.repo()
 
     query =
@@ -621,7 +641,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
     |> repo.all()
     |> Enum.filter(fn args ->
       args["resource_type"] == AITranslatable.resource_type() and
-        args["resource_uuid"] == post_uuid
+        args["resource_uuid"] == post_uuid and
+        args["resource_scope"] == scope
     end)
     |> Enum.map(& &1["target_lang"])
     |> Enum.reject(&is_nil/1)

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -15,11 +15,9 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PresenceHelpers
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
-  alias PhoenixKit.Settings
+  alias PhoenixKit.Modules.Publishing.TranslationManager
   alias PhoenixKitAI, as: AI
   alias PhoenixKitPublishing.AITranslatable
-
-  @translation_prompt_slug "translate-publishing-posts"
 
   # Core's generic-pipeline Oban worker. Referenced as a module (not a bare
   # string) so the name stays in sync with core and the coupling is greppable;
@@ -43,8 +41,6 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   """
   def ai_translation_available?, do: Translations.available?()
 
-  defp ai_module_available?, do: Code.ensure_loaded?(PhoenixKitAI)
-
   @doc """
   Lists available AI endpoints for translation as `[{uuid, name}]`.
   """
@@ -55,46 +51,24 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   """
   def list_ai_prompts, do: Translations.list_prompts()
 
+  # Default endpoint/prompt resolution is domain logic shared with the
+  # programmatic bulk API — TranslationManager owns it so the two paths can't
+  # drift. These stay as the editor's entry points but just delegate.
+
   @doc """
   Gets the default AI endpoint UUID from settings.
   """
-  def get_default_ai_endpoint_uuid do
-    case Settings.get_setting("publishing_translation_endpoint_uuid") do
-      nil -> nil
-      "" -> nil
-      id -> id
-    end
-  end
+  def get_default_ai_endpoint_uuid, do: TranslationManager.default_endpoint_uuid()
 
   @doc """
-  Gets the default AI prompt UUID for translation from settings.
+  Gets the default AI prompt UUID for translation (setting, then slug fallback).
   """
-  def get_default_ai_prompt_uuid do
-    case Settings.get_setting("publishing_translation_prompt_uuid") do
-      nil -> fallback_prompt_uuid()
-      "" -> fallback_prompt_uuid()
-      id -> id
-    end
-  end
-
-  defp fallback_prompt_uuid do
-    if ai_module_available?() and AI.enabled?() do
-      case AI.get_prompt_by_slug(@translation_prompt_slug) do
-        nil -> nil
-        prompt -> prompt.uuid
-      end
-    else
-      nil
-    end
-  end
+  def get_default_ai_prompt_uuid, do: TranslationManager.default_prompt_uuid()
 
   @doc """
   Checks if the default translation prompt already exists.
   """
-  def default_translation_prompt_exists? do
-    ai_module_available?() and AI.enabled?() and
-      AI.get_prompt_by_slug(@translation_prompt_slug) != nil
-  end
+  def default_translation_prompt_exists?, do: TranslationManager.default_prompt_exists?()
 
   @doc """
   Generates the default translation prompt in the AI prompts system.

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -20,8 +20,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   alias PhoenixKitAI.Translations
   alias PhoenixKitPublishing.AITranslatable
 
-  # Core's generic-pipeline Oban worker. Referenced as a module (not a bare
-  # string) so the name stays in sync with core and the coupling is greppable;
+  # PhoenixKitAI's generic translation worker. Referenced as a module (not a bare
+  # string) so the name stays in sync and the coupling is greppable;
   # `Oban.Job.worker` stores `inspect/1` of the worker module.
   @translate_worker PhoenixKitAI.TranslateWorker
 
@@ -30,7 +30,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   # ============================================================================
 
   # Availability + endpoint/prompt listing are generic across every
-  # AI-translation consumer, so they delegate to core
+  # AI-translation consumer, so they delegate to
   # `PhoenixKitAI.Translations` — the canonical implementation —
   # rather than re-deriving the same `{uuid, name}` shape here. (Catalogue
   # and projects share the same core helpers.) Publishing keeps its own
@@ -270,7 +270,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
     # source used by build_translation_warnings/2.
     source_language = source_language_for_translation(socket)
 
-    # One Oban job per target language (core's generic pipeline) so they run
+    # One Oban job per target language (PhoenixKitAI's generic pipeline) so they run
     # in parallel — replaces the legacy single-job sequential worker.
     base_params = %{
       resource_type: AITranslatable.resource_type(),
@@ -676,7 +676,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
     end
   end
 
-  # Target languages with a non-terminal generic-pipeline translation job for
+  # Target languages with a non-terminal PhoenixKitAI translation job for
   # THIS post AND THIS version (`scope`). Scoping by version matters now that
   # each version translates independently — otherwise a v2 editor would restore
   # v1's in-progress banner. `scope` is nil (active version) or the version

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -476,7 +476,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
           content = source_post.content || ""
           String.trim(content) == ""
 
-        {:error, _} ->
+        _ ->
           # Can't read source - assume it's blank to be safe
           true
       end

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -71,6 +71,43 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   def default_translation_prompt_exists?, do: TranslationManager.default_prompt_exists?()
 
   @doc """
+  Whether the persisted default prompt is **stale** — it exists but predates the
+  lowercase-placeholder standardization, so it still references `{{Title}}`/
+  `{{Content}}` and would not bind the adapter's `title`/`content` keys (the
+  model would hallucinate). Drives a "Regenerate default prompt" affordance so a
+  stale row isn't a dead end (the "Generate" button hides once a prompt exists).
+  """
+  def default_translation_prompt_stale? do
+    case persisted_default_prompt() do
+      %{content: content} when is_binary(content) ->
+        not (String.contains?(content, "{{title}}") and String.contains?(content, "{{content}}"))
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
+  Repairs a stale default prompt by rewriting its content to the current
+  template **in place** (preserving its uuid + any endpoint wiring), or creates
+  it if absent. Returns `{:ok, prompt}` or `{:error, reason}`.
+  """
+  def regenerate_default_translation_prompt do
+    case persisted_default_prompt() do
+      nil -> generate_default_translation_prompt()
+      prompt -> AI.update_prompt(prompt, %{content: default_prompt_content()})
+    end
+  end
+
+  defp persisted_default_prompt do
+    if Code.ensure_loaded?(PhoenixKitAI) and AI.enabled?() do
+      AI.get_prompt_by_slug(TranslationManager.translation_prompt_slug())
+    else
+      nil
+    end
+  end
+
+  @doc """
   Generates the default translation prompt in the AI prompts system.
   Returns {:ok, prompt} or {:error, changeset}.
   """

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -174,23 +174,26 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   Gets target languages for translation (missing languages only).
   """
   def get_target_languages_for_translation(socket) do
-    post = socket.assigns.post
-    # Use post's stored primary language for translation source
-    primary_language = LanguageHelpers.get_primary_language()
-    available_languages = post.available_languages || []
-
-    Publishing.enabled_language_codes()
-    |> Enum.reject(&(&1 == primary_language or &1 in available_languages))
+    # Core owns the "enabled minus primary minus already-translated" rule
+    # (same helper catalogue/projects use) — don't re-derive it here.
+    Translations.missing_languages(
+      Publishing.enabled_language_codes(),
+      LanguageHelpers.get_primary_language(),
+      socket.assigns.post.available_languages || []
+    )
   end
 
   @doc """
   Gets all target languages for translation (all except primary).
   """
   def get_all_target_languages(_socket) do
-    primary_language = LanguageHelpers.get_primary_language()
-
-    Publishing.enabled_language_codes()
-    |> Enum.reject(&(&1 == primary_language))
+    # "All enabled except primary" is the missing-languages rule with an empty
+    # existing-set.
+    Translations.missing_languages(
+      Publishing.enabled_language_codes(),
+      LanguageHelpers.get_primary_language(),
+      []
+    )
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -10,13 +10,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
 
   import Ecto.Query, only: [from: 2]
 
-  alias PhoenixKitAI.Translations
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Constants
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PresenceHelpers
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.TranslationManager
   alias PhoenixKitAI, as: AI
+  alias PhoenixKitAI.Translations
   alias PhoenixKitPublishing.AITranslatable
 
   # Core's generic-pipeline Oban worker. Referenced as a module (not a bare
@@ -336,15 +337,35 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   def build_translation_warnings(socket, target_languages) do
     warnings = []
 
-    # Check if source content is blank
+    # Warn about a blank source, distinguishing which field is missing. The
+    # source has two translatable fields (title + body content), so a blanket
+    # "content is empty" misleads when only the title is filled — that title
+    # still translates fine.
     warnings =
-      if source_content_blank?(socket) do
-        [
-          {:warning, gettext("The source content is empty. This will create empty translations.")}
-          | warnings
-        ]
-      else
-        warnings
+      case source_blank_state(socket) do
+        {true, true} ->
+          [
+            {:warning,
+             gettext("The source has no title or content — the translations will be empty.")}
+            | warnings
+          ]
+
+        {false, true} ->
+          [
+            {:warning,
+             gettext("The source has no body content — only the title will be translated.")}
+            | warnings
+          ]
+
+        {true, false} ->
+          [
+            {:warning,
+             gettext("The source has no title — only the body content will be translated.")}
+            | warnings
+          ]
+
+        {false, false} ->
+          warnings
       end
 
     # Check if any target languages have existing content that will be overwritten
@@ -505,35 +526,70 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   end
 
   @doc """
-  Checks if the source content is blank.
+  Checks if the source body content is blank. Kept for callers that only care
+  about the body; `source_blank_state/1` is the richer title+content variant.
   """
   def source_content_blank?(socket) do
-    post = socket.assigns.post
+    {_title_blank, content_blank} = source_blank_state(socket)
+    content_blank
+  end
 
-    # Source is ALWAYS the primary language (the content actually fed to the
-    # translator), never the language the editor happens to be viewing — same
-    # invariant as do_enqueue_translation/2 and build_translation_warnings/2.
-    # Checking the viewed language here would warn "source is empty" about a
-    # translation, or stay silent while the real (primary) source is blank.
+  @doc """
+  Returns `{title_blank?, content_blank?}` for the translation source.
+
+  The source feeds two translatable fields — the title and the body content —
+  so the confirmation modal can warn precisely (nothing, only-title, or
+  only-content) instead of a blanket "content is empty". The effective title
+  mirrors the adapter's `extract_title/1`: the first `# heading` of the body,
+  else the stored/typed title (the default `"Untitled"` counts as no title).
+  """
+  def source_blank_state(socket) do
+    {title, content} = source_title_and_content(socket)
+    {blank_title?(title, content), String.trim(content) == ""}
+  end
+
+  # Source is ALWAYS the primary language (the content actually fed to the
+  # translator), never the language the editor happens to be viewing — same
+  # invariant as do_enqueue_translation/2 and build_translation_warnings/2.
+  # When viewing the source language the live buffer is authoritative;
+  # otherwise read the primary row from the database.
+  defp source_title_and_content(socket) do
+    post = socket.assigns.post
     source_language = source_language_for_translation(socket)
     current_version = socket.assigns[:current_version]
 
-    # If we're already viewing the source language, the live buffer is
-    # authoritative; otherwise read the primary content from the database.
     if socket.assigns[:current_language] == source_language do
-      content = socket.assigns.content || ""
-      String.trim(content) == ""
+      {live_form_title(socket), socket.assigns.content || ""}
     else
       case Publishing.read_post_by_uuid(post.uuid, source_language, current_version) do
         {:ok, source_post} ->
-          content = source_post.content || ""
-          String.trim(content) == ""
+          {db_metadata_title(source_post), source_post.content || ""}
 
+        # Can't read source - treat as fully blank to be safe.
         _ ->
-          # Can't read source - assume it's blank to be safe
-          true
+          {"", ""}
       end
     end
+  end
+
+  defp live_form_title(socket) do
+    socket.assigns |> Map.get(:form, %{}) |> Map.get("title", "")
+  end
+
+  defp db_metadata_title(post) do
+    post |> Map.get(:metadata, %{}) |> Map.get(:title, "")
+  end
+
+  # Mirrors AITranslatable.extract_title/1: a `# heading` in the body wins,
+  # otherwise the metadata/form title; the default "Untitled" is not a title.
+  defp blank_title?(title_meta, content) do
+    effective =
+      case Regex.run(~r/^#\s+(.+)$/m, content || "") do
+        [_, heading] -> String.trim(heading)
+        nil -> title_meta |> to_string() |> String.trim()
+      end
+
+    effective == "" or effective == Constants.default_title()
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -10,7 +10,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
 
   import Ecto.Query, only: [from: 2]
 
-  alias PhoenixKit.Modules.AI.Translations
+  alias PhoenixKitAI.Translations
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PresenceHelpers
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
   # Core's generic-pipeline Oban worker. Referenced as a module (not a bare
   # string) so the name stays in sync with core and the coupling is greppable;
   # `Oban.Job.worker` stores `inspect/1` of the worker module.
-  @translate_worker PhoenixKit.Modules.AI.TranslateWorker
+  @translate_worker PhoenixKitAI.TranslateWorker
 
   # ============================================================================
   # Availability Checks
@@ -30,7 +30,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
 
   # Availability + endpoint/prompt listing are generic across every
   # AI-translation consumer, so they delegate to core
-  # `PhoenixKit.Modules.AI.Translations` — the canonical implementation —
+  # `PhoenixKitAI.Translations` — the canonical implementation —
   # rather than re-deriving the same `{uuid, name}` shape here. (Catalogue
   # and projects share the same core helpers.) Publishing keeps its own
   # *default* endpoint/prompt resolution below, since those read

--- a/mix.exs
+++ b/mix.exs
@@ -64,14 +64,28 @@ defmodule PhoenixKitPublishing.MixProject do
     ]
   end
 
+  # phoenix_kit deps resolve from Hex by default. For cross-repo work against a
+  # local checkout, export <APP>_PATH — e.g. PHOENIX_KIT_PATH=../phoenix_kit or
+  # PHOENIX_KIT_AI_PATH=../phoenix_kit_ai. Unset => the published pin, so
+  # mix hex.publish is unaffected.
+  defp pk_dep(app, requirement, opts \\ []) do
+    env_var = String.upcase(Atom.to_string(app)) <> "_PATH"
+
+    case System.get_env(env_var) do
+      nil when opts == [] -> {app, requirement}
+      nil -> {app, requirement, opts}
+      path -> {app, [path: path, override: true] ++ opts}
+    end
+  end
+
   defp deps do
     [
       # PhoenixKit provides the Module behaviour, Settings API, and core infrastructure.
       # 1.7.132 is the floor — it carries the generic AI-translation pipeline
       # (`Modules.AI.{Translatable,Translations,TranslateWorker}` +
       # `ai_translatables/0`) that `ai_translatable.ex` plugs into.
-      {:phoenix_kit, "~> 1.7.132"},
-      {:phoenix_kit_ai, "~> 0.3"},
+      pk_dep(:phoenix_kit, "~> 1.7.132"),
+      pk_dep(:phoenix_kit_ai, "~> 0.3"),
 
       # LiveView for admin pages
       {:phoenix_live_view, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule PhoenixKitPublishing.MixProject do
       # 1.7.132 is the floor — it carries the generic AI-translation pipeline
       # (`Modules.AI.{Translatable,Translations,TranslateWorker}` +
       # `ai_translatables/0`) that `ai_translatable.ex` plugs into.
-      {:phoenix_kit, "~> 1.7.132"},
+      {:phoenix_kit, "~> 1.7.133"},
       {:phoenix_kit_ai, "~> 0.1"},
 
       # LiveView for admin pages

--- a/mix.exs
+++ b/mix.exs
@@ -70,8 +70,8 @@ defmodule PhoenixKitPublishing.MixProject do
       # 1.7.132 is the floor — it carries the generic AI-translation pipeline
       # (`Modules.AI.{Translatable,Translations,TranslateWorker}` +
       # `ai_translatables/0`) that `ai_translatable.ex` plugs into.
-      {:phoenix_kit, "~> 1.7.133"},
-      {:phoenix_kit_ai, "~> 0.1"},
+      {:phoenix_kit, "~> 1.7.132"},
+      {:phoenix_kit_ai, "~> 0.3"},
 
       # LiveView for admin pages
       {:phoenix_live_view, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -81,10 +81,9 @@ defmodule PhoenixKitPublishing.MixProject do
   defp deps do
     [
       # PhoenixKit provides the Module behaviour, Settings API, and core infrastructure.
-      # 1.7.132 is the floor — it carries the generic AI-translation pipeline
-      # (`Modules.AI.{Translatable,Translations,TranslateWorker}` +
-      # `ai_translatables/0`) that `ai_translatable.ex` plugs into.
       pk_dep(:phoenix_kit, "~> 1.7.132"),
+      # PhoenixKitAI owns the generic AI-translation pipeline that this module's
+      # `AITranslatable` adapter plugs into.
       pk_dep(:phoenix_kit_ai, "~> 0.3"),
 
       # LiveView for admin pages

--- a/test/phoenix_kit_publishing/ai_translatable_test.exs
+++ b/test/phoenix_kit_publishing/ai_translatable_test.exs
@@ -1,9 +1,9 @@
 defmodule PhoenixKitPublishing.AITranslatableTest do
   @moduledoc """
   Unit coverage for the `PhoenixKitAI.Translatable` adapter that wires
-  publishing posts into core's generic AI-translation pipeline. Covers the four
+  publishing posts into PhoenixKitAI's generic AI-translation pipeline. Covers the four
   callbacks (fetch / source_fields / put_translation / pubsub_topics) and the
-  local url_slug generation. The actual AI call + fan-out live in core.
+  local url_slug generation. The actual AI call + fan-out live in PhoenixKitAI.
   """
   use PhoenixKitPublishing.DataCase, async: false
 

--- a/test/phoenix_kit_publishing/ai_translatable_test.exs
+++ b/test/phoenix_kit_publishing/ai_translatable_test.exs
@@ -81,13 +81,14 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
       {:ok, resource} = AITranslatable.fetch("publishing_post", post_uuid)
       fields = AITranslatable.source_fields(resource, "en-US")
 
-      # Capitalized keys to match the prompt's {{Title}}/{{Content}} placeholders.
-      # Core's prompt substitution is case-sensitive, so the exact key casing is
-      # load-bearing — lowercase keys leave the placeholders unrendered and the
-      # model hallucinates. Pin the key set, not just the values.
-      assert Enum.sort(Map.keys(fields)) == ["Content", "Title"]
-      assert fields["Title"] == "Hello World"
-      assert fields["Content"] =~ "The body."
+      # Lowercase keys to match the prompt's {{title}}/{{content}} placeholders
+      # (same convention as catalogue/projects). Core's prompt substitution is
+      # case-sensitive, so the exact key casing is load-bearing — a mismatch
+      # leaves the placeholders unrendered and the model hallucinates. Pin the
+      # key set, not just the values.
+      assert Enum.sort(Map.keys(fields)) == ["content", "title"]
+      assert fields["title"] == "Hello World"
+      assert fields["content"] =~ "The body."
     end
   end
 
@@ -99,7 +100,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
                AITranslatable.put_translation(
                  resource,
                  "ru",
-                 %{"Title" => "Привет мир", "Content" => "# Привет мир\n\nтекст"},
+                 %{"title" => "Привет мир", "content" => "# Привет мир\n\nтекст"},
                  []
                )
 
@@ -118,7 +119,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
         AITranslatable.put_translation(
           other_res,
           "ru",
-          %{"Title" => "Привет мир", "Content" => "x"},
+          %{"title" => "Привет мир", "content" => "x"},
           []
         )
 
@@ -133,7 +134,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
         AITranslatable.put_translation(
           resource,
           "ru",
-          %{"Title" => "Привет мир", "Content" => "y"},
+          %{"title" => "Привет мир", "content" => "y"},
           []
         )
 

--- a/test/phoenix_kit_publishing/ai_translatable_test.exs
+++ b/test/phoenix_kit_publishing/ai_translatable_test.exs
@@ -81,8 +81,13 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
       {:ok, resource} = AITranslatable.fetch("publishing_post", post_uuid)
       fields = AITranslatable.source_fields(resource, "en-US")
 
-      assert fields["title"] == "Hello World"
-      assert fields["content"] =~ "The body."
+      # Capitalized keys to match the prompt's {{Title}}/{{Content}} placeholders.
+      # Core's prompt substitution is case-sensitive, so the exact key casing is
+      # load-bearing — lowercase keys leave the placeholders unrendered and the
+      # model hallucinates. Pin the key set, not just the values.
+      assert Enum.sort(Map.keys(fields)) == ["Content", "Title"]
+      assert fields["Title"] == "Hello World"
+      assert fields["Content"] =~ "The body."
     end
   end
 
@@ -94,7 +99,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
                AITranslatable.put_translation(
                  resource,
                  "ru",
-                 %{"title" => "Привет мир", "content" => "# Привет мир\n\nтекст"},
+                 %{"Title" => "Привет мир", "Content" => "# Привет мир\n\nтекст"},
                  []
                )
 
@@ -113,7 +118,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
         AITranslatable.put_translation(
           other_res,
           "ru",
-          %{"title" => "Привет мир", "content" => "x"},
+          %{"Title" => "Привет мир", "Content" => "x"},
           []
         )
 
@@ -128,7 +133,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
         AITranslatable.put_translation(
           resource,
           "ru",
-          %{"title" => "Привет мир", "content" => "y"},
+          %{"Title" => "Привет мир", "Content" => "y"},
           []
         )
 

--- a/test/phoenix_kit_publishing/ai_translatable_test.exs
+++ b/test/phoenix_kit_publishing/ai_translatable_test.exs
@@ -11,6 +11,7 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
   alias PhoenixKit.Modules.Publishing.Groups
   alias PhoenixKit.Modules.Publishing.Posts
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
+  alias PhoenixKit.Modules.Publishing.Versions
   alias PhoenixKit.Settings
   alias PhoenixKitPublishing.AITranslatable
 
@@ -140,6 +141,41 @@ defmodule PhoenixKitPublishing.AITranslatableTest do
 
       {:ok, ru} = Publishing.read_post_by_uuid(post_uuid, "ru")
       assert ru.url_slug == "hello-world"
+    end
+  end
+
+  describe "fetch/3 version scoping" do
+    test "targets the version named by the scope, not just the active one",
+         %{group_slug: group_slug, post_uuid: post_uuid} do
+      # v1 (from setup) has "# Hello World\n\nThe body."
+      {:ok, v1} = Publishing.read_post_by_uuid(post_uuid, "en-US")
+      assert v1.version == 1
+
+      # Branch a v2 draft (copies v1), then give it distinct content.
+      {:ok, _} = Versions.create_new_version(group_slug, v1, %{})
+      {:ok, v2} = Publishing.read_post_by_uuid(post_uuid, "en-US", 2)
+
+      {:ok, _} =
+        Publishing.update_post(
+          group_slug,
+          v2,
+          %{"title" => "Second Version", "content" => "# Second Version\n\nv2 body."},
+          %{}
+        )
+
+      # scope "1" pins v1 and reads v1's source content...
+      {:ok, r1} = AITranslatable.fetch("publishing_post", post_uuid, "1")
+      assert r1.version == 1
+      assert AITranslatable.source_fields(r1, "en-US")["content"] =~ "The body."
+
+      # ...scope "2" pins v2 and reads v2's source content.
+      {:ok, r2} = AITranslatable.fetch("publishing_post", post_uuid, "2")
+      assert r2.version == 2
+      assert AITranslatable.source_fields(r2, "en-US")["content"] =~ "v2 body."
+
+      # A non-numeric scope falls back gracefully (nil → active version).
+      {:ok, r_bad} = AITranslatable.fetch("publishing_post", post_uuid, "garbage")
+      assert is_integer(r_bad.version)
     end
   end
 

--- a/test/phoenix_kit_publishing/ai_translatable_test.exs
+++ b/test/phoenix_kit_publishing/ai_translatable_test.exs
@@ -1,6 +1,6 @@
 defmodule PhoenixKitPublishing.AITranslatableTest do
   @moduledoc """
-  Unit coverage for the `PhoenixKit.Modules.AI.Translatable` adapter that wires
+  Unit coverage for the `PhoenixKitAI.Translatable` adapter that wires
   publishing posts into core's generic AI-translation pipeline. Covers the four
   callbacks (fetch / source_fields / put_translation / pubsub_topics) and the
   local url_slug generation. The actual AI call + fan-out live in core.

--- a/test/phoenix_kit_publishing/editor_translation_test.exs
+++ b/test/phoenix_kit_publishing/editor_translation_test.exs
@@ -14,6 +14,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.TranslationTest do
   alias PhoenixKit.Modules.Publishing.Posts
   alias PhoenixKit.Modules.Publishing.Web.Editor.Translation
   alias PhoenixKit.Settings
+  alias PhoenixKitPublishing.AITranslatable
 
   setup do
     {:ok, _} = Settings.update_boolean_setting("languages_enabled", true)
@@ -71,6 +72,40 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.TranslationTest do
       s = socket(%{post: post, current_language: "en-US", current_version: nil, content: ""})
 
       assert Translation.source_content_blank?(s)
+    end
+  end
+
+  describe "prompt/adapter variable contract" do
+    test "shipped prompt placeholders exactly match the adapter's source_fields keys",
+         %{post: post} do
+      # The 2026-06-07 regression: source_fields/2 returned lowercase keys while
+      # the prompt used {{Title}}/{{Content}}. Core's substitution is
+      # case-sensitive, so the placeholders rendered literally and the model
+      # hallucinated. Pin the invariant: every {{Placeholder}} in the shipped
+      # prompt (minus the core-provided language slots) must be a key the
+      # adapter actually binds — same string, same casing.
+      {:ok, resource} = AITranslatable.fetch("publishing_post", post.uuid)
+
+      bound_keys =
+        resource
+        |> AITranslatable.source_fields("en-US")
+        |> Map.keys()
+        |> MapSet.new()
+
+      placeholders =
+        ~r/\{\{(\w+)\}\}/
+        |> Regex.scan(Translation.default_prompt_content())
+        |> Enum.map(fn [_, name] -> name end)
+        |> Enum.reject(&(&1 in ["SourceLanguage", "TargetLanguage"]))
+        |> MapSet.new()
+
+      assert placeholders == bound_keys,
+             """
+             Prompt placeholders and adapter source_fields keys have drifted.
+             Prompt {{...}} (minus language slots): #{inspect(MapSet.to_list(placeholders))}
+             source_fields/2 keys:                  #{inspect(MapSet.to_list(bound_keys))}
+             They must match byte-for-byte (core substitution is case-sensitive).
+             """
     end
   end
 end

--- a/test/phoenix_kit_publishing/editor_translation_test.exs
+++ b/test/phoenix_kit_publishing/editor_translation_test.exs
@@ -1,0 +1,76 @@
+defmodule PhoenixKit.Modules.Publishing.Web.Editor.TranslationTest do
+  @moduledoc """
+  Unit coverage for the editor's AI-translation source-language resolution.
+
+  Regression guard: the translation **source** is always the primary language
+  (the canonical content), never the language the editor happens to be viewing.
+  A non-primary page with an empty buffer must NOT report the source as blank
+  when the primary language has content.
+  """
+  use PhoenixKitPublishing.DataCase, async: false
+
+  alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Groups
+  alias PhoenixKit.Modules.Publishing.Posts
+  alias PhoenixKit.Modules.Publishing.Web.Editor.Translation
+  alias PhoenixKit.Settings
+
+  setup do
+    {:ok, _} = Settings.update_boolean_setting("languages_enabled", true)
+
+    {:ok, _} =
+      Settings.update_json_setting("languages_config", %{
+        "languages" => [
+          %{
+            "code" => "en-US",
+            "name" => "English",
+            "is_default" => true,
+            "is_enabled" => true,
+            "position" => 0
+          },
+          %{
+            "code" => "ru",
+            "name" => "Russian",
+            "is_default" => false,
+            "is_enabled" => true,
+            "position" => 1
+          }
+        ]
+      })
+
+    {:ok, group} = Groups.add_group("Tr #{System.unique_integer([:positive])}", mode: "slug")
+    {:ok, post} = Posts.create_post(group["slug"], %{title: "Hello World", slug: "hello-world"})
+
+    {:ok, _} =
+      Publishing.update_post(
+        group["slug"],
+        post,
+        %{"title" => "Hello World", "content" => "# Hello World\n\nThe body."},
+        %{}
+      )
+
+    %{post: post}
+  end
+
+  defp socket(assigns) do
+    %Phoenix.LiveView.Socket{assigns: Map.merge(%{__changed__: %{}}, assigns)}
+  end
+
+  describe "source_content_blank?/1" do
+    test "reads the primary language as source on a non-primary page", %{post: post} do
+      # Viewing the (empty) ru language. The source is en-US, which has content,
+      # so this must NOT report the source as blank — otherwise the editor warns
+      # "source is empty" and the user thinks the translation will be empty.
+      s = socket(%{post: post, current_language: "ru", current_version: nil, content: ""})
+
+      refute Translation.source_content_blank?(s)
+    end
+
+    test "uses the live buffer when viewing the primary language", %{post: post} do
+      # On the primary language an empty buffer genuinely means an empty source.
+      s = socket(%{post: post, current_language: "en-US", current_version: nil, content: ""})
+
+      assert Translation.source_content_blank?(s)
+    end
+  end
+end

--- a/test/phoenix_kit_publishing/editor_translation_test.exs
+++ b/test/phoenix_kit_publishing/editor_translation_test.exs
@@ -75,6 +75,77 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.TranslationTest do
     end
   end
 
+  describe "source_blank_state/1" do
+    # {title_blank?, content_blank?} drives the precise translation-modal warning.
+
+    test "reports both blank on an empty primary buffer with no title", %{post: post} do
+      s =
+        socket(%{
+          post: post,
+          current_language: "en-US",
+          current_version: nil,
+          content: "",
+          form: %{"title" => ""}
+        })
+
+      assert Translation.source_blank_state(s) == {true, true}
+    end
+
+    test "title-only: a typed title with empty content is not 'both blank'", %{post: post} do
+      # The case the user flagged: only a title is filled. The title still
+      # translates, so the warning must say "only the title" — not "empty".
+      s =
+        socket(%{
+          post: post,
+          current_language: "en-US",
+          current_version: nil,
+          content: "",
+          form: %{"title" => "My Title"}
+        })
+
+      assert Translation.source_blank_state(s) == {false, true}
+    end
+
+    test "content-only: body text with no title/heading reports title blank", %{post: post} do
+      s =
+        socket(%{
+          post: post,
+          current_language: "en-US",
+          current_version: nil,
+          content: "Just some body text, no heading.",
+          form: %{"title" => ""}
+        })
+
+      assert Translation.source_blank_state(s) == {true, false}
+    end
+
+    test "a `# heading` counts as a title even with a blank title field", %{post: post} do
+      s =
+        socket(%{
+          post: post,
+          current_language: "en-US",
+          current_version: nil,
+          content: "# Real Heading\n\nBody.",
+          form: %{"title" => ""}
+        })
+
+      assert Translation.source_blank_state(s) == {false, false}
+    end
+
+    test "the default \"Untitled\" title does not count as a title", %{post: post} do
+      s =
+        socket(%{
+          post: post,
+          current_language: "en-US",
+          current_version: nil,
+          content: "",
+          form: %{"title" => "Untitled"}
+        })
+
+      assert Translation.source_blank_state(s) == {true, true}
+    end
+  end
+
   describe "prompt/adapter variable contract" do
     test "shipped prompt placeholders exactly match the adapter's source_fields keys",
          %{post: post} do

--- a/test/phoenix_kit_publishing/pubsub_test.exs
+++ b/test/phoenix_kit_publishing/pubsub_test.exs
@@ -236,8 +236,12 @@ defmodule PhoenixKit.Modules.Publishing.PubSubTest do
       group = "tg-#{System.unique_integer([:positive])}"
       slug = "hello"
       :ok = PublishingPubSub.subscribe_to_post_translations(group, slug)
+      # Default (arity-3) call → nil version in the payload.
       :ok = PublishingPubSub.broadcast_translation_created(group, slug, "fr")
-      assert_receive {:translation_created, ^group, ^slug, "fr"}, 500
+      assert_receive {:translation_created, ^group, ^slug, "fr", nil}, 500
+      # Explicit version rides the payload so editors can filter by it.
+      :ok = PublishingPubSub.broadcast_translation_created(group, slug, "de", "2")
+      assert_receive {:translation_created, ^group, ^slug, "de", "2"}, 500
       :ok = PublishingPubSub.broadcast_translation_deleted(group, slug, "fr")
       assert_receive {:translation_deleted, ^group, ^slug, "fr"}, 500
       PublishingPubSub.unsubscribe_from_post_translations(group, slug)

--- a/test/phoenix_kit_publishing/translation_manager_bulk_test.exs
+++ b/test/phoenix_kit_publishing/translation_manager_bulk_test.exs
@@ -20,7 +20,7 @@ defmodule PhoenixKitPublishing.TranslationManagerBulkTest do
   @base_opts [endpoint_uuid: "ep-uuid", prompt_uuid: "pr-uuid", source_language: "en"]
 
   describe "build_bulk_translation_params/2" do
-    test "assembles core generic-pipeline params from explicit opts" do
+    test "assembles PhoenixKitAI translation params from explicit opts" do
       {base, targets} =
         TranslationManager.build_bulk_translation_params(
           @post,

--- a/test/phoenix_kit_publishing/translation_manager_bulk_test.exs
+++ b/test/phoenix_kit_publishing/translation_manager_bulk_test.exs
@@ -8,7 +8,9 @@ defmodule PhoenixKitPublishing.TranslationManagerBulkTest do
 
   Passing `:source_language` + `:target_languages` keeps these pure (no DB /
   Languages-config dependency): the default-resolution branch that reads
-  `LanguageHelpers` only fires when those opts are omitted.
+  `LanguageHelpers` only fires when those opts are omitted. An explicit
+  `:resource_scope` likewise skips the active-version lookup (which rescues to
+  `nil` without a DB connection).
   """
   use ExUnit.Case, async: true
 
@@ -22,7 +24,7 @@ defmodule PhoenixKitPublishing.TranslationManagerBulkTest do
       {base, targets} =
         TranslationManager.build_bulk_translation_params(
           @post,
-          @base_opts ++ [target_languages: ["es", "fr"]]
+          @base_opts ++ [target_languages: ["es", "fr"], resource_scope: "1"]
         )
 
       assert base == %{
@@ -30,7 +32,8 @@ defmodule PhoenixKitPublishing.TranslationManagerBulkTest do
                resource_uuid: @post,
                endpoint_uuid: "ep-uuid",
                prompt_uuid: "pr-uuid",
-               source_lang: "en"
+               source_lang: "en",
+               resource_scope: "1"
              }
 
       assert targets == ["es", "fr"]


### PR DESCRIPTION
## What
Moves publishing's AI translation onto the shared `phoenix_kit_ai` pipeline, finishes the version-scoped translation work, and tightens editor UX. Paired with BeamLabEU/phoenix_kit_ai#10 (and core's AI-table-only change).

## AI translation: move to the plugin
- Rewire the adapter, translation manager, and editor translation flow from core's `PhoenixKit.Modules.AI.*` to `PhoenixKitAI.*`.
- Adapter is duck-typed `ai_translatables/0` (no `@impl PhoenixKit.Module`), discovered by `PhoenixKitAI.Translatables`.
- `mix.exs`: `{:phoenix_kit_ai, "~> 0.3"}` + floating core minimum. No `@version` bump.
- Standardize on the lowercase `"title"`/`"content"` field convention (matches catalogue/projects); fixes a case-sensitivity regression where capitalized `{{Title}}` placeholders rendered literally and the model hallucinated.

## Version-scoped translation (F1/F2/F3)
- Translate the **version the editor is on** (a draft), not always the active one — `resource_scope` threads through dedup + broadcasts + `fetch/3`.
- Regenerate affordance for stale default prompts.
- Unified default endpoint/prompt resolution.

## Editor fixes (this round)
- **Duplicate-slug error** now names the offending slug and notes it's unique within the group, across the create / in-place-update / version paths (was a generic "A post with that slug already exists").
- **AI-translation source warning** distinguishes *nothing* / *only-title* / *only-content* instead of a blanket "source content is empty" that fired even when a title was present. (+5 tests)
- **Translation modal**: reasoning-model hint under the endpoint selector + a clearer "runs in the background, you can keep editing or leave" line (parity with catalogue/projects).
- Credo alias-order cleanups (AI-move leftovers).

## Notes
- `mix format` + `mix credo --strict` clean; targeted tests pass.
- Gated on `phoenix_kit_ai` releasing `0.3` (the `~> 0.3` pin) — assume-merge order: ai → this.

---

**Also in this PR (latest push):** an env-gated `pk_dep/3` path override in `mix.exs` so this package can build/test against a local `phoenix_kit*` checkout via `<APP>_PATH` (e.g. `PHOENIX_KIT_PATH=../phoenix_kit mix test`). Unset = the published pin, so `mix deps.get` / `mix hex.publish` / CI resolve exactly as before. Adds a "Local cross-repo development" section to `AGENTS.md`.