### PR TITLE
Editor & public rendering: robust images, URL healing, OpenGraph, descriptive errors, slug safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,7 @@ Add new error atoms by extending `@type error_atom`, the doctest example, and ad
 | `publishing_render_cache_enabled` | `true` | Toggle the Markdown render cache (global) |
 | `publishing_render_cache_enabled_<slug>` | `true` | Per-group override for the render cache |
 | `publishing_show_language_switcher` | `true` | Render the in-page language switcher on listing + post pages. Disable when the host layout already provides one (see "Language switcher integration" below) |
+| `publishing_render_og_tags` | `true` | Render OpenGraph + Twitter Card meta tags **in-page** (inside the public body) so social previews work even when the host root layout doesn't render the forwarded `:og` assign in `<head>`. Disable when the host renders `:og` in `<head>` itself, to avoid duplicate tags (see "OpenGraph metadata" below) |
 
 ## Language switcher integration
 
@@ -445,6 +446,12 @@ Publishing assigns a `:og` map on every public response for host root layouts to
 - **Post pages** — `%{title, description, image, url, locale, type: "article"}` (6 fields). `description` and `image` may be `nil` when the post has no SEO metadata or featured image.
 
 `:og` lands on `conn.assigns` AND is forwarded through `LayoutWrapper.app_layout`'s `:module_assigns` map, so hosts can consume it from either `root.html.heex` (the conn assign) OR `Layouts.app/1` (the forwarded `@og` assign). The forwarding happens in publishing's three public render branches (`all_groups/1`, `index/1`, `show/1` in `Web.HTML`) the same way `:phoenix_kit_publishing_translations` does — see the function-component-layout callout above for the boundary mechanism.
+
+### Automatic in-page rendering (default on)
+
+Meta tags belong in `<head>`, which the **host app owns** — and most hosts ship their own `root.html.heex` that doesn't render the forwarded `:og`, so relying on the host alone left previews broken. So publishing **also renders the og/twitter tags itself**, in-page, via `Web.HTML.og_meta_tags/1` (rendered as the first child inside `LayoutWrapper.app_layout` in all three public branches). This mirrors the in-page language switcher: it works out of the box with zero host setup. Body placement is read by the major scrapers (FB/Slack/Discord/Telegram/LinkedIn); `<head>` is still the strict-standard location, which is what the `module_assigns` pass-along is for.
+
+The `publishing_render_og_tags` setting (default `true`) gates the in-page copy. A host that renders the forwarded `:og` in its own `<head>` (e.g. via core's `root.html.heex`, which renders the full og+twitter+canonical block) should flip it **off** from `/admin/settings/publishing` to avoid duplicate tags. The setting is read per-request in `og_tags_enabled?/0` — it is **not** part of the Markdown render cache (that caches post-body HTML only), so toggling takes effect immediately. The component renders nothing when `:og` is absent (e.g. the groups overview).
 
 ## Testing
 

--- a/lib/phoenix_kit_publishing/errors.ex
+++ b/lib/phoenix_kit_publishing/errors.ex
@@ -17,6 +17,9 @@ defmodule PhoenixKit.Modules.Publishing.Errors do
       `{:ai_extract_failed, reason}`, `{:ai_request_failed, reason}`,
       `{:source_post_read_failed, reason}`
     * strings — passed through unchanged (legacy / interpolated messages)
+    * `%Ecto.Changeset{}` — a humanized, two-error-capped summary of its
+      field errors (defensive: changesets are normally normalized to atoms
+      upstream, but if one reaches the UI it must not render as a struct)
     * unknown reasons — rendered as `"Unexpected error: <inspect>"` via
       gettext so nothing ever silently surfaces a raw struct
 
@@ -68,10 +71,12 @@ defmodule PhoenixKit.Modules.Publishing.Errors do
           | :not_published
           | :post_not_found
           | :post_trashed
+          | :resource_not_found
           | :reserved_language_code
           | :reserved_route_word
           | :slug_already_exists
           | :slug_taken
+          | :timestamp_collision_unresolvable
           | :title_required
           | :unpublished
           | :version_access_disabled
@@ -117,6 +122,7 @@ defmodule PhoenixKit.Modules.Publishing.Errors do
   def message(:not_published), do: gettext("Not published")
   def message(:post_not_found), do: gettext("Post not found")
   def message(:post_trashed), do: gettext("Post is trashed")
+  def message(:resource_not_found), do: gettext("Resource not found")
 
   def message(:reserved_language_code),
     do: gettext("Slug conflicts with a reserved language code")
@@ -124,6 +130,13 @@ defmodule PhoenixKit.Modules.Publishing.Errors do
   def message(:reserved_route_word), do: gettext("Slug conflicts with a reserved route word")
   def message(:slug_already_exists), do: gettext("Slug already exists")
   def message(:slug_taken), do: gettext("Slug taken")
+
+  def message(:timestamp_collision_unresolvable),
+    do:
+      gettext(
+        "Every time slot on this post's date is taken. Change the date or time, then try again."
+      )
+
   def message(:title_required), do: gettext("Title is required to publish")
   def message(:unpublished), do: gettext("Unpublished")
   def message(:version_access_disabled), do: gettext("Version access is disabled")
@@ -149,12 +162,59 @@ defmodule PhoenixKit.Modules.Publishing.Errors do
     gettext("Failed to read source post: %{reason}", reason: truncate_for_log(reason))
   end
 
+  # Changesets normally get normalized to atoms upstream, but if one reaches
+  # the UI directly, render a short humanized summary of its field errors
+  # rather than an inspected struct. Capped at two errors so a wall of
+  # validation messages can't fill a flash; the editor form has no inline
+  # error display to fall back on, so this summary is the only signal.
+  def message(%Ecto.Changeset{} = changeset) do
+    case humanize_changeset_errors(changeset) do
+      [] -> gettext("Some fields are invalid. Please review and try again.")
+      parts -> Enum.join(parts, "; ")
+    end
+  end
+
   # Passthrough for strings so legacy callers returning {:error, "..."}
   # still render something. New code should return atoms / tagged tuples.
   def message(reason) when is_binary(reason), do: reason
 
   def message(reason) do
     gettext("Unexpected error: %{reason}", reason: truncate_for_log(reason))
+  end
+
+  defp humanize_changeset_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", safe_to_string(value))
+      end)
+    end)
+    |> Enum.flat_map(fn {field, msgs} ->
+      Enum.map(msgs, fn msg -> "#{humanize_field(field)} #{msg}" end)
+    end)
+    |> Enum.take(2)
+  end
+
+  # Ecto error opts can carry values with no String.Chars implementation
+  # (e.g. a `{:array, :string}` type, or arbitrary `add_error/4` metadata).
+  # Building the flash must never crash, so fall back to inspect/1.
+  defp safe_to_string(value) when is_binary(value), do: value
+
+  defp safe_to_string(value) do
+    to_string(value)
+  rescue
+    Protocol.UndefinedError -> inspect(value)
+  end
+
+  # "active_version_uuid" -> "Active version" — strip the internal *_uuid
+  # suffix and underscores so we don't surface raw column names to users.
+  defp humanize_field(field) do
+    field
+    |> to_string()
+    |> String.replace_suffix("_uuid", "")
+    |> String.replace("_", " ")
+    |> String.trim()
+    |> String.capitalize()
   end
 
   @doc """

--- a/lib/phoenix_kit_publishing/publishing.ex
+++ b/lib/phoenix_kit_publishing/publishing.ex
@@ -412,6 +412,14 @@ defmodule PhoenixKit.Modules.Publishing do
   end
 
   @doc """
+  Returns true when slugifying `text` would be shortened to fit the slug cap —
+  i.e. the full title didn't fit. Auto-generation never errors (it truncates);
+  this lets the editor warn that not all of the title became the slug.
+  """
+  @spec slug_truncated?(String.t() | nil) :: boolean()
+  defdelegate slug_truncated?(text), to: SlugHelpers
+
+  @doc """
   Returns true when the slug matches the allowed lowercase letters, numbers, and hyphen pattern,
   and is not a reserved language code.
 

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -14,13 +14,27 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   alias PhoenixKit.Modules.Publishing.PageBuilder
   alias PhoenixKit.Modules.Shared.Components.Image
   alias PhoenixKit.Modules.Shared.Components.Video
+  alias PhoenixKit.Modules.Storage.URLSigner
   alias PhoenixKit.Settings
   # Optional dependency — available when phoenix_kit_entities is installed
   @entity_form_mod PhoenixKitEntities.Components.EntityForm
   @compile {:no_warn_undefined, @entity_form_mod}
 
   @cache_name :publishing_posts
-  @cache_version "v2"
+  # v3: render output now heals legacy signed-file URLs against the current
+  # url_prefix/secret (see heal_signed_file_urls/1) — bump drops stale v2
+  # entries that still carry an old prefix baked into <img src>.
+  @cache_version "v3"
+
+  # Matches the internal signed-file route — `<prefix>/file/<uuid>/<variant>/<token>`
+  # — embedded as an `<img src>`. The prefix is bounded to plain path segments
+  # (`(?:/[A-Za-z0-9_-]+)*`), so this only fires on genuine root-relative app
+  # URLs: a `url_prefix` is always simple path segments. That deliberately
+  # excludes absolute (`https://…`) and protocol-relative (`//cdn…`) external
+  # URLs, and paths carrying a query string / `/file/` inside a query
+  # (`/proxy?next=/file/…`). The UUID group is a strict UUID shape so arbitrary
+  # hex-ish strings don't get re-signed into fresh 404s.
+  @signed_file_url_regex ~r|src="(?:/[A-Za-z0-9_-]+)*/file/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/([a-z0-9_]+)/[0-9a-fA-F]{4}"|
 
   @global_cache_key "publishing_render_cache_enabled"
   @per_group_cache_prefix "publishing_render_cache_enabled_"
@@ -161,10 +175,27 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
 
     # credo:disable-for-lines:2 Credo.Check.Warning.MissingMetadataKeyInLoggerConfig
     Logger.debug("Content render time: #{time}μs", content_size: byte_size(content))
-    result
+    heal_signed_file_urls(result)
   end
 
   def render_markdown(_), do: ""
+
+  # Re-resolves embedded signed-file URLs against the CURRENT url_prefix and
+  # secret. Legacy inline images stored a fully-resolved `<old-prefix>/file/...`
+  # string in the markdown body; when the host later changes its url_prefix
+  # (e.g. "/phoenix_kit" -> "/") or rotates `secret_key_base`, those frozen URLs
+  # 404. The file UUID + variant are recoverable from the path, so we re-sign at
+  # render time — healing old content with no data migration. Idempotent for
+  # content already carrying the current prefix/token. `<Image file_uuid>`
+  # components (the current format) resolve correctly on their own; this only
+  # matters for the legacy frozen-URL markdown.
+  defp heal_signed_file_urls(html) when is_binary(html) do
+    Regex.replace(@signed_file_url_regex, html, fn _full, file_uuid, variant ->
+      ~s(src="#{URLSigner.signed_url(file_uuid, variant)}")
+    end)
+  end
+
+  defp heal_signed_file_urls(other), do: other
 
   # Detect if content is pure PHK XML format (starts with <Page> or <Hero>)
   defp pure_phk_content?(content) do
@@ -591,8 +622,14 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   end
 
   defp build_cache_key(post) do
-    # Build content hash from content + metadata
-    content_to_hash = post.content <> inspect(post.metadata)
+    # Build content hash from content + metadata + the two inputs that
+    # heal_signed_file_urls/1 re-signs against: the active url_prefix and a
+    # secret-derived marker. Both participate so a prefix change OR a
+    # secret_key_base rotation invalidates cached HTML automatically — otherwise
+    # a cache hit would keep serving stale (now-404) image URLs until the
+    # content itself changed.
+    content_to_hash =
+      post.content <> inspect(post.metadata) <> url_prefix_marker() <> signer_marker()
 
     content_hash =
       :crypto.hash(:md5, content_to_hash)
@@ -602,6 +639,22 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
     identifier = post[:uuid] || post.slug
 
     "#{@cache_version}:publishing_post:#{post.group}:#{identifier}:#{post.language}:#{content_hash}"
+  end
+
+  defp url_prefix_marker do
+    PhoenixKit.Config.get_url_prefix()
+  rescue
+    _ -> ""
+  end
+
+  # A stable 4-char token over a fixed probe UUID — changes only when
+  # secret_key_base changes, so it lets the render cache key track secret
+  # rotation without exposing the secret itself.
+  @cache_signer_probe "00000000-0000-0000-0000-000000000000"
+  defp signer_marker do
+    URLSigner.generate_token(@cache_signer_probe, "cache")
+  rescue
+    _ -> ""
   end
 
   defp get_cached(key) do

--- a/lib/phoenix_kit_publishing/slug_helpers.ex
+++ b/lib/phoenix_kit_publishing/slug_helpers.ex
@@ -6,6 +6,7 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
   URL slug validation for per-language slugs, and slug generation.
   """
 
+  alias PhoenixKit.Modules.Publishing.Constants
   alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.ListingCache
@@ -17,12 +18,15 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
   @slug_style_key "publishing_slug_style"
   @default_slug_style "transliterate"
 
-  # Hard cap on generated slug length. The DB columns allow 500 chars; we cap
-  # well under that because (a) transliteration can EXPAND text (щ -> shch),
-  # so a long non-Latin title could otherwise overflow, and (b) a malformed/
-  # over-long AI-returned slug should never reach an insert. 200 is generous
-  # for SEO while leaving headroom.
-  @max_slug_length 200
+  # SEO-preferred slug length. The actual cap is `effective_max_slug_length/0`
+  # — the SMALLER of this and the real save limit (`Constants.max_slug_length`).
+  # `slugify/2` caps its output to that, so the slugified BASE of any automatic
+  # path (title -> slug, AI translation, Cyrillic transliteration which EXPANDS
+  # text — щ -> shch) is always <= the save limit and never errors on save.
+  # `generate_unique_slug/4` may append a short "-N" uniqueness suffix on top of
+  # the capped base; with the 200-vs-500 headroom that stays far under the
+  # column limit. 200 is generous for SEO and well under the 500-char columns.
+  @seo_slug_length 200
 
   # ASCII slug shape — produced by the :transliterate and :ascii styles.
   @ascii_slug_pattern ~r/^[a-z0-9]+(?:-[a-z0-9]+)*$/
@@ -104,21 +108,44 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
   def slugify(nil, _opts), do: ""
 
   def slugify(text, opts) when is_binary(text) do
-    text
-    |> do_slugify(Keyword.get(opts, :style) || slug_style())
-    |> cap_length()
+    slug = do_slugify(text, Keyword.get(opts, :style) || slug_style())
+    if Keyword.get(opts, :cap, true), do: cap_length(slug), else: slug
   end
 
   def slugify(_text, _opts), do: ""
 
-  # Truncate to @max_slug_length at a hyphen boundary so we never cut a word in
-  # half and never overflow the DB column.
+  @doc """
+  Returns true when slugifying `text` would be truncated to fit the cap — i.e.
+  the full title did NOT fully fit into the generated slug.
+
+  Lets interactive callers warn the user that not all of the title became the
+  slug (automatic generation never errors — it just shortens).
+  """
+  @spec slug_truncated?(String.t() | nil, keyword()) :: boolean()
+  def slug_truncated?(text, opts \\ [])
+  def slug_truncated?(nil, _opts), do: false
+
+  def slug_truncated?(text, opts) when is_binary(text) do
+    uncapped = slugify(text, Keyword.put(opts, :cap, false))
+    String.length(uncapped) > effective_max_slug_length()
+  end
+
+  def slug_truncated?(_text, _opts), do: false
+
+  # The effective slug cap: never larger than the save limit, so a generated
+  # slug can't fail `validate_length(:slug/:url_slug, max: max_slug_length)`.
+  defp effective_max_slug_length, do: min(@seo_slug_length, Constants.max_slug_length())
+
+  # Truncate to the effective cap at a hyphen boundary so we never cut a word in
+  # half and never overflow what save accepts.
   defp cap_length(slug) do
-    if String.length(slug) <= @max_slug_length do
+    max = effective_max_slug_length()
+
+    if String.length(slug) <= max do
       slug
     else
       slug
-      |> String.slice(0, @max_slug_length)
+      |> String.slice(0, max)
       |> String.replace(~r/-[^-]*$/, "")
       |> String.trim("-")
     end

--- a/lib/phoenix_kit_publishing/web/controller.ex
+++ b/lib/phoenix_kit_publishing/web/controller.ex
@@ -214,7 +214,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> assign(:og, %{
           title: assigns.group["name"],
           url: base_url <> listing_url,
-          locale: assigns.current_language,
+          locale: og_locale(assigns.current_language),
           type: "website"
         })
         |> maybe_assign_admin_edit(
@@ -384,7 +384,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
       description: description,
       image: absolute_url(base_url, image),
       url: absolute_url(base_url, canonical_url),
-      locale: language,
+      locale: og_locale(language),
       type: "article"
     }
   end
@@ -393,12 +393,26 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
   defp absolute_url(_base, ""), do: nil
 
   defp absolute_url(base, url) when is_binary(url) do
-    if String.starts_with?(url, "http://") or String.starts_with?(url, "https://"),
-      do: url,
-      else: base <> url
+    cond do
+      String.starts_with?(url, "http://") or String.starts_with?(url, "https://") -> url
+      # Protocol-relative (`//cdn/...`) is already absolute — leave it.
+      String.starts_with?(url, "//") -> url
+      String.starts_with?(url, "/") -> base <> url
+      # Bare relative (e.g. an admin-entered SEO `og_image` of "images/og.png")
+      # — treat as site-absolute so we don't emit "https://hostimages/og.png".
+      true -> base <> "/" <> url
+    end
   end
 
   defp absolute_url(_base, _url), do: nil
+
+  # OpenGraph wants `language_TERRITORY` (underscore); our locale codes are
+  # BCP47-style (`en-US`) or base-only (`ja`). Normalise the separator and
+  # leave base-only codes as-is (territory unknown; consumers accept
+  # language-only).
+  defp og_locale(nil), do: nil
+  defp og_locale(code) when is_binary(code), do: String.replace(code, "-", "_")
+  defp og_locale(code), do: code
 
   defp maybe_assign_admin_edit(conn, path, label) do
     mod = @admin_edit_helper_mod

--- a/lib/phoenix_kit_publishing/web/edit.ex
+++ b/lib/phoenix_kit_publishing/web/edit.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Edit do
 
   alias Phoenix.Component
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Shared
   alias PhoenixKit.Settings
@@ -107,7 +108,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Edit do
           Exception.format(:error, e, __STACKTRACE__)
       )
 
-      {:noreply, put_flash(socket, :error, gettext("Something went wrong. Please try again."))}
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         gettext("Something went wrong while saving this group.") <>
+           " " <> Errors.truncate_for_log(Exception.message(e), 200)
+       )}
   end
 
   def handle_event("cancel", _params, socket) do

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -27,6 +27,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
 
   alias Phoenix.LiveView.JS
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Shared
@@ -636,7 +637,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   rescue
     e ->
       Logger.error("Editor save failed: #{Exception.message(e)}")
-      {:noreply, put_flash(socket, :error, gettext("Something went wrong. Please try again."))}
+
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         gettext("Something went wrong while saving this post.") <>
+           " " <> Errors.truncate_for_log(Exception.message(e), 200)
+       )}
   end
 
   def handle_event("noop", _params, socket), do: {:noreply, socket}
@@ -756,12 +764,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
          |> assign(:ai_default_prompt_exists, true)
          |> Phoenix.LiveView.put_flash(:info, gettext("Default translation prompt created"))}
 
-      {:error, _changeset} ->
+      {:error, changeset} ->
         {:noreply,
          Phoenix.LiveView.put_flash(
            socket,
            :error,
-           gettext("Failed to create prompt. It may already exist.")
+           gettext("Couldn't create the default translation prompt.") <>
+             " " <> Errors.message(changeset)
          )}
     end
   end
@@ -777,12 +786,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
          |> assign(:ai_default_prompt_stale, false)
          |> Phoenix.LiveView.put_flash(:info, gettext("Default translation prompt updated"))}
 
-      {:error, _changeset} ->
+      {:error, changeset} ->
         {:noreply,
          Phoenix.LiveView.put_flash(
            socket,
            :error,
-           gettext("Failed to update the default prompt")
+           gettext("Couldn't update the default translation prompt.") <>
+             " " <> Errors.message(changeset)
          )}
     end
   end
@@ -1007,8 +1017,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
         {:noreply,
          put_flash(socket, :error, gettext("Cannot remove the last language from a post"))}
 
-      {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to clear translation"))}
+      {:error, reason} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't clear this translation.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 
@@ -1034,8 +1049,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
          |> assign(:post, saved_post)
          |> put_flash(:info, flash_msg)}
 
-      {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to update version access setting"))}
+      {:error, reason} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't update the version-access setting.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -1766,17 +1766,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     {socket, autosave?} =
       cond do
         file_uuid && inserting_image_component ->
-          file_url = Helpers.get_file_url(file_uuid)
-
-          js_code =
-            "window.publishingEditorInsertMedia && window.publishingEditorInsertMedia(#{Jason.encode!(file_url)}, 'image')"
+          markup = Helpers.image_component_markup(file_uuid)
 
           {
             socket
             |> assign(:show_media_selector, false)
             |> assign(:inserting_image_component, false)
             |> put_flash(:info, gettext("Image component inserted"))
-            |> push_event("exec-js", %{js: js_code}),
+            |> push_event("insert-media", %{text: markup}),
             false
           }
 
@@ -1882,13 +1879,29 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
         }
       });
 
-      // Listen for exec-js events from LiveView (for media insertion)
-      window.addEventListener("phx:exec-js", (e) => {
-        try {
-          eval(e.detail.js);
-        } catch (err) {
-          console.error("[ContentEditor] Error executing JS:", err);
-        }
+      // Insert raw text at the textarea cursor and notify LiveView.
+      window.publishingEditorInsertText = function(text) {
+        const textarea = document.getElementById('content-editor-textarea');
+        if (!textarea || !text) return;
+
+        const start = textarea.selectionStart || 0;
+        const currentValue = textarea.value;
+        const newValue = currentValue.substring(0, start) + text + currentValue.substring(start);
+        textarea.value = newValue;
+
+        // Move cursor after inserted text
+        const newPos = start + text.length;
+        textarea.selectionStart = textarea.selectionEnd = newPos;
+        textarea.focus();
+
+        // Trigger keyup event to update LiveView (matches phx-keyup binding on textarea)
+        textarea.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+      };
+
+      // Listen for media markup pushed from LiveView (image components, etc.).
+      // The server builds the exact text to insert, so no client-side eval.
+      window.addEventListener("phx:insert-media", (e) => {
+        window.publishingEditorInsertText(e.detail.text);
       });
 
       // Listen for video prompt event
@@ -1899,12 +1912,9 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
         }
       });
 
-      // Function to insert standard markdown media syntax at cursor position
+      // Build standard markdown media syntax and insert it (video path; image
+      // insertion now flows through the phx:insert-media event above).
       window.publishingEditorInsertMedia = function(fileUrl, mediaType, videoUrl) {
-        const textarea = document.getElementById('content-editor-textarea');
-        if (!textarea) return;
-
-        // Build standard markdown syntax: ![alt](url)
         let template;
         if (mediaType === 'image' && fileUrl) {
           template = '\n![Image description](' + fileUrl + ')\n';
@@ -1915,18 +1925,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
           return;
         }
 
-        const start = textarea.selectionStart || 0;
-        const currentValue = textarea.value;
-        const newValue = currentValue.substring(0, start) + template + currentValue.substring(start);
-        textarea.value = newValue;
-
-        // Move cursor after inserted text
-        const newPos = start + template.length;
-        textarea.selectionStart = textarea.selectionEnd = newPos;
-        textarea.focus();
-
-        // Trigger keyup event to update LiveView (matches phx-keyup binding on textarea)
-        textarea.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+        window.publishingEditorInsertText(template);
       };
     })();
     </script>

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -102,6 +102,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
       |> assign(:last_auto_slug, "")
       |> assign(:url_slug_manually_set, false)
       |> assign(:last_auto_url_slug, "")
+      |> assign(:slug_truncated, false)
       |> assign(:live_source, live_source)
       |> assign(:form_key, nil)
       |> assign(:lock_owner?, true)
@@ -524,6 +525,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     if socket.assigns.readonly? or socket.assigns.translation_locked? do
       {:noreply, socket}
     else
+      # Clear stale flashes up front so a fresh slug-truncation warning set by
+      # the slug-update step below survives this render (it used to be wiped by
+      # a clear_flash at the END of the handler).
+      socket = clear_flash(socket)
       target = Map.get(params, "_target", [])
       params = prepare_meta_params(params, target, socket)
 
@@ -1134,7 +1139,6 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     |> assign(:url_slug_manually_set, socket.assigns.url_slug_manually_set)
     |> assign(:has_pending_changes, has_changes)
     |> assign(:public_url, public_url)
-    |> clear_flash()
     |> push_event("changes-status", %{has_changes: has_changes})
     |> Forms.push_slug_events(slug_events)
   end

--- a/lib/phoenix_kit_publishing/web/editor/forms.ex
+++ b/lib/phoenix_kit_publishing/web/editor/forms.ex
@@ -6,6 +6,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Forms do
   and form state management.
   """
 
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.Constants
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
@@ -268,6 +270,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Forms do
     if not force? and slug_manually_set? do
       no_slug_update(socket)
     else
+      socket = maybe_warn_slug_truncated(socket, title)
       current_slug = socket.assigns.post.slug || Map.get(socket.assigns.form, "slug", "")
 
       case Publishing.generate_unique_slug(socket.assigns.group_slug, title, nil,
@@ -287,6 +290,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Forms do
     if not force? and url_slug_manually_set? do
       no_slug_update(socket)
     else
+      socket = maybe_warn_slug_truncated(socket, title)
       new_url_slug = Publishing.slugify(title)
       current_url_slug = Map.get(socket.assigns.form, "url_slug", "")
 
@@ -299,6 +303,33 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Forms do
   end
 
   defp no_slug_update(socket), do: {socket, socket.assigns.form, []}
+
+  # Auto-generated slugs never error — they truncate to fit. When the title was
+  # too long to fully fit, warn ONCE (a false->true transition on
+  # `:slug_truncated`) so live typing past the cap doesn't spam a flash on every
+  # keystroke. The warning clears when the title shrinks back under the cap.
+  defp maybe_warn_slug_truncated(socket, title) do
+    truncated? = Publishing.slug_truncated?(title)
+    already? = Map.get(socket.assigns, :slug_truncated, false)
+
+    cond do
+      truncated? and not already? ->
+        socket
+        |> Phoenix.Component.assign(:slug_truncated, true)
+        |> Phoenix.LiveView.put_flash(
+          :warning,
+          gettext(
+            "The title was too long for a URL, so the slug was shortened. Edit it manually if you'd like a different one."
+          )
+        )
+
+      not truncated? ->
+        Phoenix.Component.assign(socket, :slug_truncated, false)
+
+      true ->
+        socket
+    end
+  end
 
   defp apply_new_slug(socket, new_slug) do
     current_slug = Map.get(socket.assigns.form, "slug", "")

--- a/lib/phoenix_kit_publishing/web/editor/helpers.ex
+++ b/lib/phoenix_kit_publishing/web/editor/helpers.ex
@@ -6,12 +6,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Helpers do
   virtual post creation, and other common operations.
   """
 
+  require Logger
+
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.Constants
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.Web.Editor.Translation
   alias PhoenixKit.Modules.Publishing.Web.HTML, as: PublishingHTML
-  alias PhoenixKit.Modules.Storage.URLSigner
+  alias PhoenixKit.Modules.Storage
   alias PhoenixKit.Utils.Routes
 
   # ============================================================================
@@ -171,10 +173,60 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Helpers do
   end
 
   @doc """
-  Gets the URL for a media asset from storage.
+  Builds the inline `<Image>` PHK component markup for a storage file.
+
+  The component carries the **file UUID**, not a resolved URL — the renderer
+  (`PhoenixKit.Modules.Shared.Components.Image`) resolves it to a URL at render
+  time via `Storage.get_public_url_by_uuid/2`. Storing the UUID instead of a
+  signed URL keeps the reference stable across `url_prefix` changes,
+  `secret_key_base` rotation, and content moved between environments — the same
+  late-resolution the featured image already uses.
+
+  Alt text is derived from the file's original name (falling back to `"Image"`),
+  sanitised so it can't break out of the XML attribute.
   """
-  def get_file_url(file_uuid) do
-    URLSigner.signed_url(file_uuid, "original")
+  def image_component_markup(file_uuid) when is_binary(file_uuid) do
+    ~s(\n<Image file_uuid="#{file_uuid}" alt="#{alt_from_file(file_uuid)}"/>\n)
+  end
+
+  defp alt_from_file(file_uuid) do
+    case safe_get_file(file_uuid) do
+      %{original_file_name: name} when is_binary(name) and name != "" ->
+        alt_from_filename(name)
+
+      _ ->
+        "Image"
+    end
+  end
+
+  # Turn a stored filename into human-ish alt text, stripped of any characters
+  # that would terminate the `alt="..."` attribute or the component tag.
+  defp alt_from_filename(name) do
+    name
+    |> Path.rootname()
+    |> String.replace(~r/[_-]+/u, " ")
+    |> String.replace(~r/["'<>\r\n]/u, "")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+    |> String.slice(0, 100)
+    |> case do
+      "" -> "Image"
+      alt -> alt
+    end
+  end
+
+  # Best-effort: a storage/repo hiccup must never block inserting an image —
+  # we just fall back to a generic alt. Logged at debug so a persistent failure
+  # (every image degrading to alt="Image") is still diagnosable.
+  defp safe_get_file(file_uuid) do
+    Storage.get_file(file_uuid)
+  rescue
+    error ->
+      Logger.debug(
+        "Publishing: failed to resolve file #{file_uuid} for alt text: #{inspect(error)}"
+      )
+
+      nil
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/editor/persistence.ex
+++ b/lib/phoenix_kit_publishing/web/editor/persistence.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Renderer
@@ -264,7 +265,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
         })
 
       {:error, error} ->
-        handle_post_creation_error(socket, error, gettext("Failed to create post"))
+        handle_post_creation_error(socket, error, gettext("Couldn't create this post."))
     end
   end
 
@@ -303,12 +304,12 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
             )
         end
 
-      {:error, _reason} ->
+      {:error, reason} ->
         {:noreply,
          Phoenix.LiveView.put_flash(
            socket,
            :error,
-           gettext("Failed to create translation")
+           gettext("Couldn't create this translation.") <> " " <> Errors.message(reason)
          )}
     end
   end
@@ -377,7 +378,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
          Phoenix.LiveView.put_flash(
            socket,
            :error,
-           gettext("Failed to create new version: %{reason}", reason: inspect(reason))
+           gettext("Couldn't create a new version.") <> " " <> Errors.message(reason)
          )}
     end
   end
@@ -464,9 +465,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
          Phoenix.LiveView.put_flash(
            socket,
            :warning,
-           gettext("Post saved but failed to archive other versions: %{reason}",
-             reason: inspect(reason)
-           )
+           gettext("Post saved, but archiving the other versions failed.") <>
+             " " <> Errors.message(reason)
          )}
     end
   end
@@ -565,7 +565,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   defp handle_post_in_place_error(socket, reason) do
     post_id = socket.assigns[:post] && socket.assigns.post[:uuid]
     Logger.warning("[Publishing.Editor] Save failed for post #{post_id}: #{inspect(reason)}")
-    {:noreply, Phoenix.LiveView.put_flash(socket, :error, gettext("Failed to save post"))}
+
+    {:noreply,
+     Phoenix.LiveView.put_flash(
+       socket,
+       :error,
+       gettext("Couldn't save this post.") <> " " <> Errors.message(reason)
+     )}
   end
 
   defp handle_post_update_result(socket, update_result, success_message, extra_assigns) do
@@ -659,7 +665,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   defp handle_post_update_error(socket, reason) do
     post_id = socket.assigns[:post] && socket.assigns.post[:uuid]
     Logger.warning("[Publishing.Editor] Update failed for post #{post_id}: #{inspect(reason)}")
-    {:noreply, Phoenix.LiveView.put_flash(socket, :error, gettext("Failed to save post"))}
+
+    {:noreply,
+     Phoenix.LiveView.put_flash(
+       socket,
+       :error,
+       gettext("Couldn't save this post.") <> " " <> Errors.message(reason)
+     )}
   end
 
   # Clear, actionable message for a duplicate post slug. Names the offending
@@ -716,14 +728,25 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
         "[Publishing.Editor] Post creation failed in #{group}: #{inspect(changeset.errors)}"
       )
 
-      {:noreply, Phoenix.LiveView.put_flash(socket, :error, fallback_message)}
+      {:noreply,
+       Phoenix.LiveView.put_flash(
+         socket,
+         :error,
+         fallback_message <> " " <> Errors.message(changeset)
+       )}
     end
   end
 
   defp handle_post_creation_error(socket, reason, fallback_message) do
     group = socket.assigns[:group_slug]
     Logger.warning("[Publishing.Editor] Post creation failed in #{group}: #{inspect(reason)}")
-    {:noreply, Phoenix.LiveView.put_flash(socket, :error, fallback_message)}
+
+    {:noreply,
+     Phoenix.LiveView.put_flash(
+       socket,
+       :error,
+       fallback_message <> " " <> Errors.message(reason)
+     )}
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/editor/translation.ex
+++ b/lib/phoenix_kit_publishing/web/editor/translation.ex
@@ -12,6 +12,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
 
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.Constants
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PresenceHelpers
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
@@ -301,8 +302,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
 
         {:noreply, translation_success_socket(socket, in_flight)}
 
-      {:error, _reason} ->
-        {:noreply, translation_error_socket(socket)}
+      {:error, reason} ->
+        {:noreply, translation_error_socket(socket, reason)}
     end
   end
 
@@ -321,10 +322,15 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Translation do
     )
   end
 
-  defp translation_error_socket(socket) do
+  defp translation_error_socket(socket, reason \\ nil) do
+    detail = if reason, do: " " <> Errors.message(reason), else: ""
+
     socket
     |> Phoenix.Component.assign(:ai_translation_status, :error)
-    |> Phoenix.LiveView.put_flash(:error, gettext("Failed to enqueue translation job"))
+    |> Phoenix.LiveView.put_flash(
+      :error,
+      gettext("Couldn't start the translation job.") <> detail
+    )
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/editor/versions.ex
+++ b/lib/phoenix_kit_publishing/web/editor/versions.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Versions do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Shared
@@ -131,7 +132,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Versions do
           |> Phoenix.Component.assign(:show_new_version_modal, false)
           |> Phoenix.LiveView.put_flash(
             :error,
-            gettext("Failed to create new version: %{reason}", reason: inspect(reason))
+            gettext("Couldn't create a new version.") <> " " <> Errors.message(reason)
           )
 
         {:error, socket}

--- a/lib/phoenix_kit_publishing/web/html.ex
+++ b/lib/phoenix_kit_publishing/web/html.ex
@@ -10,11 +10,64 @@ defmodule PhoenixKit.Modules.Publishing.Web.HTML do
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.Renderer
   alias PhoenixKit.Modules.Storage
+  alias PhoenixKit.Settings
 
   @timestamp_modes Constants.timestamp_modes()
   @slug_modes Constants.slug_modes()
 
+  @og_render_key "publishing_render_og_tags"
+
   import PhoenixKitWeb.Components.LanguageSwitcher
+
+  @doc """
+  Renders the OpenGraph + Twitter Card meta tags for a public page from the
+  `:og` map the controller builds.
+
+  These are emitted in-page (inside the rendered body) so a social preview
+  works out of the box even when the host's root layout doesn't render the
+  forwarded `:og` assign in `<head>` — most host apps ship their own root
+  layout. The same `:og` map is ALSO forwarded via `module_assigns`, so a host
+  that does render it in `<head>` gets the strictly-correct placement; such a
+  host disables the in-page copy via `publishing_render_og_tags` to avoid
+  duplicate tags. Renders nothing when `:og` is absent (e.g. the groups index).
+  """
+  attr :og, :map, default: nil
+
+  def og_meta_tags(assigns) do
+    ~H"""
+    <%= if @og && (@og[:title] || @og[:url]) do %>
+      <meta property="og:type" content={@og[:type] || "article"} />
+      <%= if @og[:title] do %>
+        <meta property="og:title" content={@og[:title]} />
+        <meta name="twitter:title" content={@og[:title]} />
+      <% end %>
+      <%= if @og[:description] do %>
+        <meta property="og:description" content={@og[:description]} />
+        <meta name="twitter:description" content={@og[:description]} />
+      <% end %>
+      <%= if @og[:image] do %>
+        <meta property="og:image" content={@og[:image]} />
+        <meta name="twitter:image" content={@og[:image]} />
+      <% end %>
+      <meta :if={@og[:url]} property="og:url" content={@og[:url]} />
+      <meta :if={@og[:locale]} property="og:locale" content={@og[:locale]} />
+      <meta property="og:site_name" content={Settings.get_project_title()} />
+      <meta
+        name="twitter:card"
+        content={if @og[:image], do: "summary_large_image", else: "summary"}
+      />
+    <% end %>
+    """
+  end
+
+  # Whether to emit the in-page OG/Twitter tags. On by default; a host that
+  # renders the forwarded `:og` assign in its own `<head>` flips this off from
+  # /admin/settings/publishing so the tags aren't duplicated.
+  defp og_tags_enabled? do
+    Settings.get_boolean_setting(@og_render_key, true)
+  rescue
+    _ -> true
+  end
 
   def all_groups(assigns) do
     ~H"""
@@ -25,6 +78,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.HTML do
     phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
     module_assigns={%{phoenix_kit_publishing_translations: assigns[:phoenix_kit_publishing_translations], og: assigns[:og]}}
     >
+    <.og_meta_tags :if={og_tags_enabled?()} og={assigns[:og]} />
     <div class="groups-overview-container max-w-6xl mx-auto px-6 py-8">
     <%!-- Page Header --%>
     <header class="mb-8">
@@ -97,6 +151,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.HTML do
     phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
     module_assigns={%{phoenix_kit_publishing_translations: assigns[:phoenix_kit_publishing_translations], og: assigns[:og]}}
     >
+    <.og_meta_tags :if={og_tags_enabled?()} og={assigns[:og]} />
     <div class="group-index-container max-w-6xl mx-auto px-6 py-8">
     <%!-- Breadcrumb Navigation --%>
     <div class="breadcrumbs text-sm mb-6">
@@ -253,6 +308,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.HTML do
     phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
     module_assigns={%{phoenix_kit_publishing_translations: assigns[:phoenix_kit_publishing_translations], og: assigns[:og]}}
     >
+    <.og_meta_tags :if={og_tags_enabled?()} og={assigns[:og]} />
     <article class="post-container max-w-4xl mx-auto px-6 py-8">
     <%!-- Breadcrumb Navigation --%>
     <div class="breadcrumbs text-sm mb-6">

--- a/lib/phoenix_kit_publishing/web/index.ex
+++ b/lib/phoenix_kit_publishing/web/index.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Index do
 
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.Constants
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.Web.Editor.Helpers
 
   @group_statuses Constants.group_statuses()
@@ -171,7 +172,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Index do
 
       {:error, reason} ->
         Logger.warning("[Publishing.Index] Trash group failed for #{slug}: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, gettext("Failed to trash group"))}
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't move this group to trash.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 
@@ -185,7 +192,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Index do
 
       {:error, reason} ->
         Logger.warning("[Publishing.Index] Restore group failed for #{slug}: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, gettext("Failed to restore group"))}
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't restore this group.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 
@@ -202,7 +215,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Index do
 
       {:error, reason} ->
         Logger.warning("[Publishing.Index] Delete group failed for #{slug}: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, gettext("Failed to delete group"))}
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't delete this group.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/listing.ex
+++ b/lib/phoenix_kit_publishing/web/listing.ex
@@ -8,6 +8,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Listing do
   require Logger
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Shared
@@ -148,7 +149,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Listing do
 
       {:error, reason} ->
         Logger.warning("[Publishing.Listing] Trash post failed: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, gettext("Failed to trash post"))}
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't move this post to trash.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 
@@ -169,7 +176,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Listing do
 
       {:error, reason} ->
         Logger.warning("[Publishing.Listing] Restore post failed: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, gettext("Failed to restore post"))}
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't restore this post.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 
@@ -909,8 +922,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Listing do
          )
          |> reload_current_view()}
 
-      {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to update status"))}
+      {:error, reason} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't update the post status.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/settings.ex
+++ b/lib/phoenix_kit_publishing/web/settings.ex
@@ -6,6 +6,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Renderer
@@ -85,8 +86,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
          |> assign(:cache_status, build_cache_status(socket.assigns.cache_groups))
          |> put_flash(:info, gettext("Cache regenerated for %{group}", group: slug))}
 
-      {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to regenerate cache"))}
+      {:error, reason} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't regenerate the cache for this group.") <>
+             " " <> Errors.message(reason)
+         )}
     end
   end
 
@@ -192,8 +199,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
            gettext("Cleared %{count} cached posts for %{group}", count: count, group: slug)
          )}
 
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to clear cache"))}
+      {:error, reason} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Couldn't clear the cache for this group.") <> " " <> Errors.message(reason)
+         )}
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/settings.ex
+++ b/lib/phoenix_kit_publishing/web/settings.ex
@@ -19,6 +19,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
   @memory_cache_key "publishing_memory_cache_enabled"
   @render_cache_key "publishing_render_cache_enabled"
   @show_language_switcher_key "publishing_show_language_switcher"
+  @render_og_tags_key "publishing_render_og_tags"
   @slug_style_key "publishing_slug_style"
   @valid_slug_styles ~w(transliterate unicode ascii)
 
@@ -52,6 +53,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
       |> assign(
         :show_language_switcher,
         Settings.get_boolean_setting(@show_language_switcher_key, true)
+      )
+      |> assign(
+        :render_og_tags,
+        Settings.get_boolean_setting(@render_og_tags_key, true)
       )
       |> assign(:slug_style, Settings.get_setting(@slug_style_key, "transliterate"))
       |> assign(
@@ -159,6 +164,28 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
          else:
            gettext(
              "In-page language switcher disabled — host layout / custom switcher should render translations"
+           )
+       )
+     )}
+  end
+
+  def handle_event("toggle_render_og_tags", _params, socket) do
+    new_value = !socket.assigns.render_og_tags
+    Settings.update_boolean_setting(@render_og_tags_key, new_value)
+
+    {:noreply,
+     socket
+     |> assign(:render_og_tags, new_value)
+     |> put_flash(
+       :info,
+       if(new_value,
+         do:
+           gettext(
+             "In-page OpenGraph tags enabled — publishing pages will render their own social meta tags"
+           ),
+         else:
+           gettext(
+             "In-page OpenGraph tags disabled — your host layout should render the forwarded :og assign in <head>"
            )
        )
      )}
@@ -401,6 +428,26 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
               class="toggle toggle-primary"
               checked={@show_language_switcher}
               phx-click="toggle_show_language_switcher"
+            />
+          </div>
+
+          <div class="flex items-center justify-between p-4 bg-base-200 rounded-lg">
+            <div class="flex items-center gap-3">
+              <.icon name="hero-share" class="w-5 h-5 text-base-content/70" />
+              <div>
+                <p class="font-medium">{gettext("In-Page OpenGraph Tags")}</p>
+                <p class="text-xs text-base-content/60">
+                  {gettext(
+                    "Render OpenGraph + Twitter Card meta tags on listing + post pages so link previews work out of the box. Disable when your host layout renders the forwarded :og assign in <head>."
+                  )}
+                </p>
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              class="toggle toggle-primary"
+              checked={@render_og_tags}
+              phx-click="toggle_render_og_tags"
             />
           </div>
 

--- a/phk-publishing-format.md
+++ b/phk-publishing-format.md
@@ -38,7 +38,7 @@ Standard **Markdown** lives here. Use `##` for subheadings, `-` for bullet lists
 
 Inline PHK components can appear anywhere in the Markdown body:
 
-<Image file_id="019a6f96-e895-74e2-a745-1b596ee235af" file_variant="medium" alt="Screenshot" />
+<Image file_uuid="019a6f96-e895-74e2-a745-1b596ee235af" file_variant="medium" alt="Screenshot" />
 
 Continue writing Markdown below the component.
 ```
@@ -79,7 +79,7 @@ You can mix **bold text** and inline components:
 
 | Component | Notes |
 |-----------|-------|
-| `<Image … />` | Works with either `src="/path/to/file.jpg"` or `file_id="…"`. Optional `file_variant="thumbnail" | "small" | "medium" | "large"` picks a specific variant from PhoenixKit Storage. The renderer now always returns the natural dimensions; add your own `class` if you want to constrain width. |
+| `<Image … />` | Works with either `src="/path/to/file.jpg"` or `file_uuid="…"`. Optional `file_variant="thumbnail" | "small" | "medium" | "large"` picks a specific variant from PhoenixKit Storage. The renderer now always returns the natural dimensions; add your own `class` if you want to constrain width. |
 | `<Hero variant="split-image|centered|minimal"> … </Hero>` | A layout block that can wrap `<Headline>`, `<Subheadline>`, `<CTA />`, `<Image />`. Use sparingly inside Markdown (usually near the top). |
 | `<Headline>…</Headline>` | Renders a hero-style heading. |
 | `<Subheadline>…</Subheadline>` | Medium-sized supporting text. |
@@ -92,7 +92,7 @@ Additional components can be introduced by adding Phoenix components under `lib/
 
 ## Storage integration & variants
 
-When an `<Image>` references `file_id="…"`, the renderer calls `PhoenixKit.Storage.get_public_url_by_id/2`. The storage layer:
+When an `<Image>` references `file_uuid="…"`, the renderer calls `PhoenixKit.Storage.get_public_url_by_uuid/2`. The storage layer:
 
 1. Looks for a matching file + variant (`original`, `thumbnail`, `small`, `medium`, `large`, etc.).
 2. Returns the provider’s public URL if available (S3, R2, CDN…).
@@ -120,7 +120,7 @@ Thanks for building with PhoenixKit! Here are the highlights from this month.
   <Headline>Maintenance Mode v2</Headline>
   <Subheadline>Plan downtime with confidence.</Subheadline>
   <CTA primary="true" action="/admin/modules">Enable Module</CTA>
-  <Image file_id="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Maintenance Mode Screenshot" />
+  <Image file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Maintenance Mode Screenshot" />
 </Hero>
 
 ## New referral analytics
@@ -130,7 +130,7 @@ Thanks for building with PhoenixKit! Here are the highlights from this month.
 - Improved fraud detection
 
 <Image
-  file_id="019a6f96-e895-74e2-a745-1b596ee235af"
+  file_uuid="019a6f96-e895-74e2-a745-1b596ee235af"
   file_variant="thumbnail"
   class="w-full"
   alt="Referral dashboard"
@@ -159,20 +159,20 @@ published_at: 2025-07-01T10:00:00Z
   <Image src="/assets/dashboard-preview.png" alt="Dashboard Preview" />
 </Hero>
 
-<!-- Example 2: Using file_id -->
+<!-- Example 2: Using file_uuid -->
 <Hero variant="centered">
   <Headline>Storage File ID Example</Headline>
   <Subheadline>This pulls from PhoenixKit Storage.</Subheadline>
   <CTA primary="true" action="/upload">Upload Image</CTA>
-  <Image file_id="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Uploaded Image" />
+  <Image file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Uploaded Image" />
 </Hero>
 
-<!-- Example 3: Using file_id with variant -->
+<!-- Example 3: Using file_uuid with variant -->
 <Hero variant="minimal">
   <Headline>Thumbnail Variant</Headline>
   <Subheadline>Great for small inline previews.</Subheadline>
   <Image
-    file_id="018e3c4a-9f6b-7890-abcd-ef1234567890"
+    file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890"
     file_variant="thumbnail"
     alt="Thumbnail Image"
   />
@@ -183,7 +183,7 @@ published_at: 2025-07-01T10:00:00Z
   <Headline>Custom Styling</Headline>
   <Subheadline>Combine variants with Tailwind utility classes.</Subheadline>
   <Image
-    file_id="018e3c4a-9f6b-7890-abcd-ef1234567890"
+    file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890"
     file_variant="medium"
     class="border-4 border-primary"
     alt="Styled Image"

--- a/test/phoenix_kit_publishing/errors_test.exs
+++ b/test/phoenix_kit_publishing/errors_test.exs
@@ -40,6 +40,7 @@ defmodule PhoenixKit.Modules.Publishing.ErrorsTest do
       assert Errors.message(:not_published) == "Not published"
       assert Errors.message(:post_not_found) == "Post not found"
       assert Errors.message(:post_trashed) == "Post is trashed"
+      assert Errors.message(:resource_not_found) == "Resource not found"
 
       assert Errors.message(:reserved_language_code) ==
                "Slug conflicts with a reserved language code"
@@ -47,6 +48,10 @@ defmodule PhoenixKit.Modules.Publishing.ErrorsTest do
       assert Errors.message(:reserved_route_word) == "Slug conflicts with a reserved route word"
       assert Errors.message(:slug_already_exists) == "Slug already exists"
       assert Errors.message(:slug_taken) == "Slug taken"
+
+      assert Errors.message(:timestamp_collision_unresolvable) ==
+               "Every time slot on this post's date is taken. Change the date or time, then try again."
+
       assert Errors.message(:title_required) == "Title is required to publish"
       assert Errors.message(:unpublished) == "Unpublished"
       assert Errors.message(:version_access_disabled) == "Version access is disabled"
@@ -101,6 +106,62 @@ defmodule PhoenixKit.Modules.Publishing.ErrorsTest do
 
     test "nil renders via the catch-all" do
       assert Errors.message(nil) == "Unexpected error: nil"
+    end
+  end
+
+  describe "message/1 — %Ecto.Changeset{}" do
+    defp changeset_with(errors) do
+      Enum.reduce(errors, Ecto.Changeset.change({%{}, %{title: :string}}), fn
+        {field, msg, opts}, acc -> Ecto.Changeset.add_error(acc, field, msg, opts)
+        {field, msg}, acc -> Ecto.Changeset.add_error(acc, field, msg)
+      end)
+    end
+
+    test "humanizes a single field error" do
+      assert Errors.message(changeset_with([{:title, "can't be blank"}])) ==
+               "Title can't be blank"
+    end
+
+    test "strips the internal *_uuid suffix from field names" do
+      msg = Errors.message(changeset_with([{:active_version_uuid, "is invalid"}]))
+      assert msg == "Active version is invalid"
+      refute msg =~ "uuid"
+    end
+
+    test "interpolates %{...} placeholders from error opts" do
+      msg =
+        Errors.message(
+          changeset_with([{:title, "should be at most %{count} character(s)", [count: 5]}])
+        )
+
+      assert msg == "Title should be at most 5 character(s)"
+    end
+
+    test "caps the summary at two field errors" do
+      msg =
+        Errors.message(
+          changeset_with([
+            {:title, "can't be blank"},
+            {:slug, "is invalid"},
+            {:mode, "is invalid"}
+          ])
+        )
+
+      # Two errors joined by "; ", the third dropped so a flash can't be flooded.
+      assert length(String.split(msg, "; ")) == 2
+    end
+
+    test "never renders the inspected struct" do
+      refute Errors.message(changeset_with([{:title, "can't be blank"}])) =~ "Ecto.Changeset"
+    end
+
+    test "does not crash on error opts whose value has no String.Chars impl" do
+      # to_string({:array, :string}) would raise Protocol.UndefinedError;
+      # the formatter must fall back to inspect rather than crash the flash.
+      msg = Errors.message(changeset_with([{:title, "is invalid", [type: {:array, :string}]}]))
+
+      assert is_binary(msg)
+      assert msg =~ "Title is invalid"
     end
   end
 

--- a/test/phoenix_kit_publishing/renderer_test.exs
+++ b/test/phoenix_kit_publishing/renderer_test.exs
@@ -465,4 +465,61 @@ defmodule PhoenixKit.Modules.Publishing.RendererTest do
       assert is_boolean(Renderer.global_render_cache_enabled?())
     end
   end
+
+  describe "render_markdown/1 heals legacy signed-file URLs" do
+    # Tests pin url_prefix to "/", so a re-signed URL is prefixless `/file/...`.
+    @file_uuid "018e3c4a-9f6b-7890-abcd-ef1234567890"
+
+    test "rewrites a stale url_prefix on an inline image to the current prefix" do
+      # Authored when url_prefix was "/phoenix_kit"; serving now uses "/".
+      html = Renderer.render_markdown("![Shot](/phoenix_kit/file/#{@file_uuid}/original/dead)")
+
+      assert html =~ "/file/#{@file_uuid}/original/"
+      refute html =~ "/phoenix_kit/file/"
+    end
+
+    test "re-signs a legacy token (handles secret_key_base rotation)" do
+      # The stale token "dead" is replaced by a freshly computed one.
+      html = Renderer.render_markdown("![Shot](/file/#{@file_uuid}/original/dead)")
+
+      assert html =~ ~r|/file/#{@file_uuid}/original/[0-9a-f]{4}"|
+    end
+
+    test "is idempotent for an already-current prefixless URL" do
+      html = Renderer.render_markdown("![Shot](/file/#{@file_uuid}/medium/beef)")
+
+      assert html =~ "/file/#{@file_uuid}/medium/"
+      refute html =~ "/phoenix_kit/"
+    end
+
+    test "leaves absolute external image URLs untouched" do
+      url = "https://cdn.example.com/assets/photo.png"
+      html = Renderer.render_markdown("![Ext](#{url})")
+
+      assert html =~ url
+    end
+
+    test "leaves provider/CDN hash-style storage URLs untouched" do
+      url = "https://cdn.example.com/12/a1/abcdef123456/abcdef123456_original.jpg"
+      html = Renderer.render_markdown("![CDN](#{url})")
+
+      assert html =~ url
+    end
+
+    test "leaves protocol-relative external URLs untouched" do
+      # Looks like a file route but is an absolute //host/... URL — must not be
+      # rewritten to local storage.
+      url = "//cdn.example.com/x/file/#{@file_uuid}/original/dead"
+      html = Renderer.render_markdown("![PR](#{url})")
+
+      assert html =~ url
+    end
+
+    test "does not rewrite a /file/ path that lives inside a query string" do
+      url = "/proxy?next=/file/#{@file_uuid}/original/dead"
+      html = Renderer.render_markdown("[link](#{url})")
+
+      assert html =~ "/proxy?next=/file/"
+    end
+  end
 end

--- a/test/phoenix_kit_publishing/slug_helpers_test.exs
+++ b/test/phoenix_kit_publishing/slug_helpers_test.exs
@@ -8,7 +8,36 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpersTest do
 
   use ExUnit.Case, async: true
 
+  alias PhoenixKit.Modules.Publishing.Constants
   alias PhoenixKit.Modules.Publishing.SlugHelpers
+
+  describe "slug length cap + truncation" do
+    test "caps a long slug at or below the save limit" do
+      slug = SlugHelpers.slugify(String.duplicate("word ", 200), style: :ascii)
+
+      assert String.length(slug) <= Constants.max_slug_length()
+      # never cuts mid-word: ends on a complete segment
+      refute String.ends_with?(slug, "-")
+    end
+
+    test "cap: false returns the uncapped slug" do
+      uncapped = SlugHelpers.slugify(String.duplicate("word ", 200), style: :ascii, cap: false)
+
+      assert String.length(uncapped) > 200
+    end
+
+    test "slug_truncated? is true when the title overflows the cap" do
+      assert SlugHelpers.slug_truncated?(String.duplicate("word ", 200), style: :ascii)
+      # Cyrillic transliteration EXPANDS (щ -> shch), so a long Russian title
+      # also overflows — the exact reported scenario.
+      assert SlugHelpers.slug_truncated?(String.duplicate("щ", 200), style: :transliterate)
+    end
+
+    test "slug_truncated? is false for short titles and nil" do
+      refute SlugHelpers.slug_truncated?("Short Title", style: :ascii)
+      refute SlugHelpers.slug_truncated?(nil)
+    end
+  end
 
   describe "validate_slug/1" do
     test "accepts a simple lowercase slug" do

--- a/test/phoenix_kit_publishing/web/controller/og_tags_test.exs
+++ b/test/phoenix_kit_publishing/web/controller/og_tags_test.exs
@@ -1,0 +1,77 @@
+defmodule PhoenixKit.Modules.Publishing.Web.Controller.OgTagsTest do
+  @moduledoc """
+  Unit tests for the in-page OpenGraph/Twitter meta-tag component
+  (`Web.HTML.og_meta_tags/1`). Publishing renders these inside the public
+  page body so social link previews work even when the host's root layout
+  doesn't render the forwarded `:og` assign in `<head>`.
+
+  The full controller→layout render path can't be asserted here: the test
+  endpoint's stand-in `Layouts.app` only surfaces layout chrome, not the
+  publishing template's inner content (where these tags live). End-to-end
+  rendering + the `publishing_render_og_tags` toggle are verified against a
+  running host. This component test pins the tag set + conditionals.
+  """
+
+  use PhoenixKitPublishing.DataCase
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKit.Modules.Publishing.Web.HTML
+
+  defp render_og(og), do: render_component(&HTML.og_meta_tags/1, og: og)
+
+  test "renders the full OpenGraph + Twitter Card set" do
+    html =
+      render_og(%{
+        type: "article",
+        title: "Hello World",
+        description: "A nice post",
+        image: "https://cdn.example.com/x.png",
+        url: "https://example.com/blog/hello",
+        locale: "en-US"
+      })
+
+    assert html =~ ~s(<meta property="og:type" content="article">)
+    assert html =~ ~s(<meta property="og:title" content="Hello World">)
+    assert html =~ ~s(<meta name="twitter:title" content="Hello World">)
+    assert html =~ ~s(<meta property="og:description" content="A nice post">)
+    assert html =~ ~s(<meta name="twitter:description" content="A nice post">)
+    assert html =~ ~s(<meta property="og:image" content="https://cdn.example.com/x.png">)
+    assert html =~ ~s(<meta name="twitter:image" content="https://cdn.example.com/x.png">)
+    assert html =~ ~s(<meta property="og:url" content="https://example.com/blog/hello">)
+    assert html =~ ~s(<meta property="og:locale" content="en-US">)
+    assert html =~ ~s(property="og:site_name")
+    assert html =~ ~s(<meta name="twitter:card" content="summary_large_image">)
+  end
+
+  test "without an image, twitter:card falls back to summary and no og:image is emitted" do
+    html = render_og(%{type: "website", title: "Blog", url: "https://example.com/blog"})
+
+    refute html =~ "og:image"
+    refute html =~ "twitter:image"
+    assert html =~ ~s(<meta name="twitter:card" content="summary">)
+  end
+
+  test "renders nothing when there is no og data" do
+    assert String.trim(render_og(nil)) == ""
+  end
+
+  test "html-escapes attacker-influenced values (title/description/image/url)" do
+    html =
+      render_og(%{
+        type: "article",
+        title: ~s|Evil" /><script>alert(1)</script>|,
+        description: ~s(D" onload="x),
+        image: ~s(https://x/"><script>),
+        url: ~s(https://x/"><img src=x>)
+      })
+
+    # No tag breakout: the crafted markup must not survive as live HTML.
+    refute html =~ "<script>"
+    refute html =~ ~s(Evil" />)
+    refute html =~ ~s(onload="x)
+    refute html =~ ~s(<img src=x>)
+    # Dangerous chars land escaped inside the attribute value.
+    assert html =~ "&quot;" or html =~ "&gt;"
+  end
+end

--- a/test/phoenix_kit_publishing/web/editor/helpers_test.exs
+++ b/test/phoenix_kit_publishing/web/editor/helpers_test.exs
@@ -170,4 +170,35 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.HelpersTest do
       assert Helpers.build_public_url(post, "en") == nil
     end
   end
+
+  describe "image_component_markup/1" do
+    # No DB here, so the storage lookup is rescued to nil and alt falls back to
+    # "Image". The point of these tests is the *shape*: a UUID-carrying <Image>
+    # component, NOT a frozen signed URL baked into the markdown.
+    test "builds a self-closing <Image> carrying the file UUID" do
+      markup = Helpers.image_component_markup(@post_uuid)
+
+      assert markup =~ ~s(<Image file_uuid="#{@post_uuid}")
+      assert markup =~ "/>"
+      assert markup =~ ~s(alt=")
+    end
+
+    test "stores the UUID reference, not a resolved /file/ URL" do
+      markup = Helpers.image_component_markup(@post_uuid)
+
+      refute markup =~ "/file/"
+      refute markup =~ "!["
+    end
+
+    test "falls back to a generic alt when the file can't be resolved" do
+      assert Helpers.image_component_markup(@post_uuid) =~ ~s(alt="Image")
+    end
+
+    test "is detected as an embedded component by the renderer" do
+      markup = Helpers.image_component_markup(@post_uuid)
+
+      # The mixed-content renderer keys off the literal "<Image " marker.
+      assert markup =~ "<Image "
+    end
+  end
 end

--- a/test/phoenix_kit_publishing/web/editor_live_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_live_test.exs
@@ -255,6 +255,27 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       assert is_binary(html)
     end
 
+    test "save failure surfaces a descriptive flash, not a bare generic one",
+         %{conn: conn, group: group, post: post} do
+      {:ok, view, _html} =
+        conn
+        |> put_test_scope(fake_scope())
+        |> live("/admin/publishing/#{group["slug"]}/#{post[:uuid]}/edit")
+
+      _ = render_change(view, "update_meta", %{"title" => "Saved Title", "_target" => ["title"]})
+      _ = render_change(view, "update_content", %{"content" => "## Body"})
+
+      html = render_click(view, "save", %{})
+
+      # fake_scope's actor uuid is not a real user row, so the audit FK fails
+      # and the save errors. The flash must carry the reason via Errors.message,
+      # never the old bare "Failed to save post". (The apostrophe in "Couldn't"
+      # is HTML-escaped in the rendered output, so match the unambiguous tail.)
+      assert html =~ "save this post."
+      assert html =~ "does not exist"
+      refute html =~ "Failed to save post"
+    end
+
     test "save with empty title flashes warning (Persistence guard)",
          %{conn: conn, group: group, post: post} do
       {:ok, view, _html} =

--- a/test/phoenix_kit_publishing/web/editor_live_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_live_test.exs
@@ -698,4 +698,41 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       refute html =~ "British Title"
     end
   end
+
+  describe "auto-slug truncation warning" do
+    test "warns when a too-long title shortens the auto-generated slug", %{
+      conn: conn,
+      group: group
+    } do
+      {:ok, view, _html} =
+        conn
+        |> put_test_scope(fake_scope())
+        |> live("/admin/publishing/#{group["slug"]}/new")
+
+      # A long Russian title transliterates (щ -> shch) far past the slug cap,
+      # so auto-generation truncates it — and must warn rather than error.
+      html =
+        render_change(view, "update_meta", %{
+          "title" => String.duplicate("щ", 200),
+          "_target" => ["title"]
+        })
+
+      assert html =~ "shortened"
+    end
+
+    test "does not warn for a title that fits", %{conn: conn, group: group} do
+      {:ok, view, _html} =
+        conn
+        |> put_test_scope(fake_scope())
+        |> live("/admin/publishing/#{group["slug"]}/new")
+
+      html =
+        render_change(view, "update_meta", %{
+          "title" => "A Short Title",
+          "_target" => ["title"]
+        })
+
+      refute html =~ "shortened"
+    end
+  end
 end


### PR DESCRIPTION
A sweep over the publishing editor + public rendering surface. Five independent, self-contained changes (one commit each); all on top of `0.1.15`.

## 1. Inline post images as `<Image>` components, not frozen URLs
The editor's image toolbar resolved a signed file URL at insert time and baked the full `/prefix/file/<uuid>/<variant>/<token>` string into the markdown — freezing it against the install's `url_prefix` and secret. Now it inserts `<Image file_uuid="…" alt="…"/>` (resolved to a URL at render time, like the featured image already was). Alt text comes from the file's original name. Also drops a client-side `eval()` (image insert now uses a typed `phx:insert-media` event) and fixes the PHK format doc (`file_id` → `file_uuid`).

## 2. Heal legacy signed-file image URLs at render time
Posts authored before #1 stored a fully-resolved `/<old-prefix>/file/…` URL. After a `url_prefix` change (e.g. `/phoenix_kit` → `/`) or a `secret_key_base` rotation, those 404. The renderer now re-signs them against the current prefix/secret (UUID + variant recovered from the path) — heals old content with no migration, idempotent for current output, and leaves absolute/external URLs untouched. Render cache key is now prefix/secret-aware.

## 3. Descriptive editor & admin error flashes
Generic catch-alls flashed flat strings ("Failed to save post", "Something went wrong") while logging the real reason. They now route through the existing `Publishing.Errors` mapper (e.g. "Couldn't save this post. Database update failed."), plus an `%Ecto.Changeset{}` clause that renders a humanized, capped field summary instead of an inspected struct.

## 4. Automatic in-page OpenGraph
`:og` was built and forwarded via `module_assigns`, but most host root layouts don't render it — so social previews were broken. Publishing now renders the OG/Twitter tags in-page itself (zero host setup), while keeping the pass-along for hosts that render them in `<head>`. New `publishing_render_og_tags` setting (default on) + a settings toggle to disable the in-page copy and avoid duplicates. Also hardens the `:og` builder (absolute-URL normalization for relative SEO images; `og:locale` in `language_TERRITORY` form).

## 5. Couple slug cap to the save limit + warn on auto-truncation
The auto-generated slug cap (200) was a hardcoded constant decoupled from the actual save limit. It's now `min(SEO 200, Constants.max_slug_length)`, so an auto-generated slug provably can't exceed what save accepts — a long Cyrillic title (transliteration expands, щ → shch) truncates safely instead of erroring. Adds a non-blocking warning flash when an automatic path shortens a slug (transition-gated, no keystroke spam). Manual edits still error if too long.

## Verification
- `mix precommit` clean (compile `--warnings-as-errors`, format, credo `--strict`, dialyzer 0 errors) on `0.1.15` with the upgraded deps (phoenix_live_view 1.2).
- Full suite green; ~30 new tests across the five areas.
- Browser/live verified on the parent app: image heal serves 200 (old URL 404/401), OG renders + toggle works, slug truncation warns + saves, descriptive save-error flash, and a live AI translation round-trip (en→de) still succeeds end-to-end.