### PR TITLE
Adversarial full-module audit: fix 9 High / 16 Medium / 12 Low findings + PR #24 review catch-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,14 @@ lib/phoenix_kit_publishing/
 
 All 4 tables use UUIDv7 primary keys. **Migrations live in phoenix_kit core** — `phoenix_kit_publishing_*` tables are created by V59 and evolved in later V*.ex files. There is no module-owned migration; tests delegate schema setup to `Ecto.Migrator.run(TestRepo, [{0, PhoenixKit.Migration}], :up, ...)` (see `test/test_helper.exs`), the same call the host app makes in production.
 
+> **TODO (next publishing core migration):** add a partial UNIQUE index on
+> `phoenix_kit_publishing_contents (version_uuid?/group, language, url_slug)` for
+> non-trashed rows. Custom `url_slug` uniqueness is currently enforced only at the
+> application level (`SlugHelpers.url_slug_exists?/4`, which now fails closed) — a
+> race or a path that skips the check can still write a duplicate, after which the
+> public read-path auto-renamer has to clean it up. A DB constraint would make it
+> impossible at the source. (Surfaced by the M13 audit fix.)
+
 ```
 Group (1) ──→ (many) Post (1) ──→ (many) Version (1) ──→ (many) Content
 ```

--- a/FOLLOW_UP.md
+++ b/FOLLOW_UP.md
@@ -1,0 +1,118 @@
+# Follow-up — adversarial full-module audit
+
+After-action report for the fixes made in response to the adversarial review of
+`phoenix_kit_publishing`. All work is local commits on top of `5e4582a`; nothing
+pushed. Suite (with the integration tier actually running): **1126 tests, 0
+failures**, stable across repeated runs; `mix format`, `mix credo --strict`, and
+`mix dialyzer` all clean.
+
+> Note on the test tier: the integration suite (`:integration`, ~520 tests) only
+> runs when the Postgres test DB exists. It is present and running here, so the
+> 1126 count includes it — every fix below was exercised against the DB tier.
+
+## Fixed (with regression tests unless noted)
+
+### High
+- **H1** — the `:publishing_posts` render cache was never supervised, so caching
+  silently no-op'd and every published view re-rendered. Declared it as a
+  supervised, size-bounded child of `Publishing.children/0`.
+- **H8** — `allow_version_access` was missing from the cached listing map, so the
+  public version dropdown only appeared on a cache miss. Mirrored it in all
+  `build_listing_metadata/4` clauses.
+- **H4** — disabled-module requests 302-looped to the same URL forever; added a
+  `:module_disabled -> :no_fallback` clause (renders 404).
+- **H5** — future-dated timestamp posts in ≥2 languages 302-ping-ponged forever;
+  applied the future-date gate in the language-fallback chain.
+- **H3** — `RouterDispatch` hijacked any host URL whose 2nd segment matched a group
+  (`/company/news`, `/api/news`); now requires segment 0 to be an enabled language
+  and passes through non-GET/HEAD requests.
+- **H2** — the previous-slug 301 system had no writer; `upsert_post_content` now
+  records the old `url_slug` in `previous_url_slugs` on a rename (deduped, drops
+  the new slug so a revert can't self-redirect).
+- **H6** — read-only collaborative spectators could drive several write paths
+  (autosave, editor_content_changed, preview, translate_*, create_version);
+  added the missing `readonly?` guards.
+- **H9** — editor reload paths read the latest version while pinned to an older
+  one; `re_read_post` now defaults to the socket's `current_version`.
+
+### Medium
+- **M1** — the timestamp-collision retry matched the wrong changeset key (`:post_*`
+  instead of the composite's first field `:group_uuid`); now matches the
+  constraint name like `StaleFixer.slug_conflict?`.
+- **M2** — `find_available_timestamp` probed with a trashed-excluding query while
+  the unique index includes trashed rows; added trashed-inclusive
+  `DBStorage.timestamp_slot_taken?/3`.
+- **M3** — the three coupled writes of a post update were non-transactional, so a
+  failure between the content-row wipe and the version-level promotion destroyed
+  the legacy V1 keys; wrapped them in one transaction.
+- **M6** — UUID lookups ignored the URL group (`/<any-group>/<uuid>` served a
+  foreign post; editor minted slugs against the wrong group); both paths now
+  require the post to belong to the requested group.
+- **M8** — the regeneration-lock ETS table was owned by a transient request
+  process and died with it (later lock ops 500'd a read); added a supervised
+  `ListingCache.LockTableOwner`.
+- **M9 (partial)** — the read-path empty-post hard-delete 500'd on a
+  concurrent-delete race; rescued `Ecto.StaleEntryError`. (Design questions below.)
+- **M10** — markdown prose normalizers corrupted fenced code (indentation strip,
+  `&nbsp;` injection); they now run only on prose between code regions.
+- **M11** — multi-line `<Image\n …/>` (spec-canonical) wasn't detected as a
+  component; detection now matches `<Image` + any whitespace/`>`.
+- **M12** — raw HTML in a fence rendered live on the plain path; code regions are
+  now escaped on that path too.
+- **M13 (partial)** — `url_slug_exists?` failed open on a DB error; now fails
+  closed. (Remaining parts below.)
+- **M15** — switching version/language mid-translation left the editor locked;
+  `handle_params` now resets the translation lock on each post-scope load.
+- **M16** — the admin group-insight counted published-only on a warm cache and
+  all-non-trashed on a cold one; always reads `list_posts` now.
+
+### Low
+- **L1** — `switch_version` crashed the LV on a non-integer `?v=`; parses
+  defensively via `parse_version_param/1`.
+
+## Surfaced for your decision — NOT changed
+
+These are real findings I deliberately did not fix autonomously (out of scope,
+invasive, a product decision, or environment-specific). Each needs your call.
+
+- **M4 — publish atomicity.** `update_version_defaults` can commit
+  `status="published"` while the paired `Versions.publish_version` (separate
+  transaction) rolls back, leaving published-with-no-active-version (admin shows
+  published, public 404s). Fixing it means either making publish atomic
+  (restructuring the publish flow) or adding a StaleFixer demotion rule — both
+  carry real risk of breaking publish. Recommend we pair on the approach.
+- **M5 — per-post SEO/OG overrides are write-only.** `params["seo"]` is persisted
+  but `get_seo` has no readers and `build_metadata`/`build_og_data` never expose
+  it, so stored `og_title/og_description/og_image` overrides never render. This is
+  a half-built *feature* (not a regression); wiring the read side is functionality
+  to add, so it's your call whether to finish or drop it.
+- **M7 / M14 — clustered-deploy only.** No cross-node cache invalidation (the
+  `:cache_changed` PubSub handler is a no-op), and `PresenceHelpers` calls
+  `Process.alive?/1` on possibly-remote pids (raises on 2+ nodes). N/A for
+  single-node hosting; fix if/when we cluster.
+- **M9 design parts.** Beyond the race fix: the empty-post deletion is a *hard*
+  delete on the *read* path (the code's stated rationale is avoiding a
+  restore→trash loop), `content_empty?` ignores `version.data` (a
+  featured-image-only version counts as empty), and it writes no ActivityLog /
+  cache invalidation. Whether to trash-instead-of-delete and/or move it to a
+  batch pass is a design decision.
+- **M13 remaining.** No DB unique index backs `url_slug` (adding one is a **core**
+  migration); the read-path auto-renamer is newest-wins with no previous-slug
+  record; and `validate_url_slug` doesn't reject claiming another post's previous
+  slug (now that H2 makes previous slugs real, this can hijack 301 traffic).
+- **H7 — `<Hero>`/`<Page>` components don't exist.** The PageBuilder resolves them
+  to `Shared.Components.{Page,Hero}`, which core doesn't ship, so every `<Hero>`
+  block renders an error div. Decision: ship the components in **core** or cut the
+  resolver clauses + spec sections here.
+- **Core-side (`phoenix_kit`) signed-file URLs.** Tokens are 16-bit, never expire
+  (the "expired token" message is false), `/api/files/:uuid/info` hands out valid
+  signed URLs for any uuid, and a nil `secret_key_base` degrades to a predictable
+  no-secret hash. Low impact for public post images; out of scope for this module.
+- **Remaining Lows (L2–L12) + nits.** e.g. preview swallows a save failure (L2);
+  pre-lock read in `do_unpublish_post` (L3); non-transactional blank-version
+  creation (L4); timestamp timezone inconsistency between create vs edit (L5);
+  group-slug rename doesn't invalidate the old cache entry (L6); double-backtick /
+  blockquoted-fence code spans aren't masked from component detection (L8);
+  per-save `:persistent_term` churn / GC pressure (L12); `should_create_new_version?`
+  hardcoded `false`; dead preview-token feature. Happy to work through these in a
+  follow-up pass — flagging rather than parking them.

--- a/FOLLOW_UP.md
+++ b/FOLLOW_UP.md
@@ -2,7 +2,7 @@
 
 After-action report for the audit-driven work on `phoenix_kit_publishing`. All work is
 local commits on top of `5e4582a`; nothing pushed. Suite (integration tier running):
-**1132 tests, 0 failures**; `mix format`, `mix credo --strict`, `mix dialyzer` clean.
+**1134 tests, 0 failures**; `mix format`, `mix credo --strict`, `mix dialyzer` clean.
 
 > The integration tier (`:integration`, ~520 tests) only runs when the Postgres test DB
 > exists — it does here, so every fix below was exercised against the DB tier.
@@ -23,10 +23,12 @@ collisions + previous-slug containment + explain-and-link conflict modal · M14 
 safe presence (clustering) · M15 stale translation lock · M16 admin-insight cache flip.
 
 **Low + nits:** L1 switch_version crash · L2 preview save-failure · L3 unpublish pre-lock
-read · L4 transactional blank-version · L6 group-rename cache invalidation · L8 double-
-backtick code spans · L9 preserve unresolved `{{placeholder}}` · L11 narrowed update
-rescue · title `phx-debounce` · canonical/302 query-string preservation · reserved route
-words on post/group slugs.
+read · L4 transactional blank-version · L5 stamp timestamp posts in the site time zone ·
+L6 group-rename cache invalidation · L7 erase whole cache on disable · L8 double-backtick
+code spans · L9 preserve unresolved `{{placeholder}}` · L10 token-scoped lock release ·
+L11 narrowed update rescue · L12 fold timestamps into the posts term (cut churn) · title
+`phx-debounce` · canonical/302 query-string preservation · reserved route words on
+post/group slugs.
 
 **H7 (boss-approved):** removed `<Hero>`/`<Page>` — they resolved to core modules deleted
 with the Pages module (core 0fc3de09).
@@ -34,33 +36,14 @@ with the Pages module (core 0fc3de09).
 **Docs:** unique-index TODO in this `AGENTS.md`; signed file-URL hardening note in core
 `AGENTS.md`.
 
-## Surfaced — NOT changed (your call)
+## Open
 
-- **L5 — timestamp timezone inconsistency.** Creation stamps UTC, but editing
-  `published_at` (a `datetime-local` input) appends `:00Z`, treating the browser's local
-  wall-clock as UTC (`forms.ex` ~159). Created vs edited posts can disagree about which
-  day they live under. The correct fix needs the browser's TZ offset (or sending UTC from
-  the client) — a real design decision, and a rushed timezone change risks making it
-  worse. Recommend we decide the canonical behavior together.
-- **L7 — re-enabling the memory cache can serve pre-disable data.** While disabled, reads
-  already return `:cache_miss` (no stale serve); the gap is the brief window after
-  re-enabling before regeneration, since old `:persistent_term` entries were never erased.
-  Fixing it well means erasing across all groups on toggle (not trivially enumerable) —
-  worth a small dedicated change, not a tail-of-session patch.
-- **L10 — stale-lock takeover can be undone by a slow original holder.** The lock's
-  `after: :ets.delete` is unconditional, so a slow original holder can delete the
-  taker's lock → a brief *duplicate* regeneration (the reviewer confirmed: not
-  corruption). Fixing it cleanly needs a per-acquisition lock token.
-- **L12 — `:persistent_term` write churn.** Every save rebuilds the listing term + writes
-  two always-changing timestamp terms, and each `:persistent_term.put` triggers a global
-  GC pass — recurring whole-VM pause pressure with large listings + autosave traffic. The
-  cheap win is folding the timestamps into the posts term; it's a perf refactor that only
-  bites at scale.
 - **M13 inline cross-post slug edit** — the conflict modal names + links the other post;
   editing *its* slug from inside the modal (cross-post mutation: its version, its previous-
   slug recording, its cache, concurrent-edit handling) is a tracked follow-up.
 - **M13 #1 / core signed-URLs** — documented as TODOs (publishing + core `AGENTS.md`),
   both needing a migration / core changes.
 
-Each of the four Lows above is a deliberate "surface, don't rush" — say the word on any
-and I'll do it as a focused change with its own tests.
+The four previously-surfaced Lows (L5, L7, L10, L12) are now **fixed** above — each as a
+focused commit with its own regression test. The two items here need a migration / core
+work, so they stay tracked rather than parked.

--- a/FOLLOW_UP.md
+++ b/FOLLOW_UP.md
@@ -1,118 +1,66 @@
 # Follow-up — adversarial full-module audit
 
-After-action report for the fixes made in response to the adversarial review of
-`phoenix_kit_publishing`. All work is local commits on top of `5e4582a`; nothing
-pushed. Suite (with the integration tier actually running): **1126 tests, 0
-failures**, stable across repeated runs; `mix format`, `mix credo --strict`, and
-`mix dialyzer` all clean.
+After-action report for the audit-driven work on `phoenix_kit_publishing`. All work is
+local commits on top of `5e4582a`; nothing pushed. Suite (integration tier running):
+**1132 tests, 0 failures**; `mix format`, `mix credo --strict`, `mix dialyzer` clean.
 
-> Note on the test tier: the integration suite (`:integration`, ~520 tests) only
-> runs when the Postgres test DB exists. It is present and running here, so the
-> 1126 count includes it — every fix below was exercised against the DB tier.
+> The integration tier (`:integration`, ~520 tests) only runs when the Postgres test DB
+> exists — it does here, so every fix below was exercised against the DB tier.
 
 ## Fixed (with regression tests unless noted)
 
-### High
-- **H1** — the `:publishing_posts` render cache was never supervised, so caching
-  silently no-op'd and every published view re-rendered. Declared it as a
-  supervised, size-bounded child of `Publishing.children/0`.
-- **H8** — `allow_version_access` was missing from the cached listing map, so the
-  public version dropdown only appeared on a cache miss. Mirrored it in all
-  `build_listing_metadata/4` clauses.
-- **H4** — disabled-module requests 302-looped to the same URL forever; added a
-  `:module_disabled -> :no_fallback` clause (renders 404).
-- **H5** — future-dated timestamp posts in ≥2 languages 302-ping-ponged forever;
-  applied the future-date gate in the language-fallback chain.
-- **H3** — `RouterDispatch` hijacked any host URL whose 2nd segment matched a group
-  (`/company/news`, `/api/news`); now requires segment 0 to be an enabled language
-  and passes through non-GET/HEAD requests.
-- **H2** — the previous-slug 301 system had no writer; `upsert_post_content` now
-  records the old `url_slug` in `previous_url_slugs` on a rename (deduped, drops
-  the new slug so a revert can't self-redirect).
-- **H6** — read-only collaborative spectators could drive several write paths
-  (autosave, editor_content_changed, preview, translate_*, create_version);
-  added the missing `readonly?` guards.
-- **H9** — editor reload paths read the latest version while pinned to an older
-  one; `re_read_post` now defaults to the socket's `current_version`.
+**High:** H1 supervise the render cache · H2 write `previous_url_slugs` (301s) ·
+H3 router host-route-hijack + method gate · H4/H5 two infinite-redirect loops ·
+H6 spectator write guards · H8 version dropdown (mapper field) · H9 reload version-pinning.
 
-### Medium
-- **M1** — the timestamp-collision retry matched the wrong changeset key (`:post_*`
-  instead of the composite's first field `:group_uuid`); now matches the
-  constraint name like `StaleFixer.slug_conflict?`.
-- **M2** — `find_available_timestamp` probed with a trashed-excluding query while
-  the unique index includes trashed rows; added trashed-inclusive
-  `DBStorage.timestamp_slot_taken?/3`.
-- **M3** — the three coupled writes of a post update were non-transactional, so a
-  failure between the content-row wipe and the version-level promotion destroyed
-  the legacy V1 keys; wrapped them in one transaction.
-- **M6** — UUID lookups ignored the URL group (`/<any-group>/<uuid>` served a
-  foreign post; editor minted slugs against the wrong group); both paths now
-  require the post to belong to the requested group.
-- **M8** — the regeneration-lock ETS table was owned by a transient request
-  process and died with it (later lock ops 500'd a read); added a supervised
-  `ListingCache.LockTableOwner`.
-- **M9 (partial)** — the read-path empty-post hard-delete 500'd on a
-  concurrent-delete race; rescued `Ecto.StaleEntryError`. (Design questions below.)
-- **M10** — markdown prose normalizers corrupted fenced code (indentation strip,
-  `&nbsp;` injection); they now run only on prose between code regions.
-- **M11** — multi-line `<Image\n …/>` (spec-canonical) wasn't detected as a
-  component; detection now matches `<Image` + any whitespace/`>`.
-- **M12** — raw HTML in a fence rendered live on the plain path; code regions are
-  now escaped on that path too.
-- **M13 (partial)** — `url_slug_exists?` failed open on a DB error; now fails
-  closed. (Remaining parts below.)
-- **M15** — switching version/language mid-translation left the editor locked;
-  `handle_params` now resets the translation lock on each post-scope load.
-- **M16** — the admin group-insight counted published-only on a warm cache and
-  all-non-trashed on a cold one; always reads `list_posts` now.
+**Medium:** M1 timestamp-collision retry (constraint-name match) · M2 trashed-slot
+availability · M3 transactional post update · M4 atomic publish + StaleFixer demotion
+heal · M5 remove dead per-post SEO/OG scaffolding · M6 cross-group UUID access ·
+M7 cross-node cache invalidation (clustering) · M8 supervised lock-table + crash-proof
+guard · M9 trash-not-delete + featured-image emptiness + ActivityLog · M10/M11/M12 code-
+region integrity / multi-line `<Image>` / consistent escaping · M13 incumbent-wins
+collisions + previous-slug containment + explain-and-link conflict modal · M14 remote-pid-
+safe presence (clustering) · M15 stale translation lock · M16 admin-insight cache flip.
 
-### Low
-- **L1** — `switch_version` crashed the LV on a non-integer `?v=`; parses
-  defensively via `parse_version_param/1`.
+**Low + nits:** L1 switch_version crash · L2 preview save-failure · L3 unpublish pre-lock
+read · L4 transactional blank-version · L6 group-rename cache invalidation · L8 double-
+backtick code spans · L9 preserve unresolved `{{placeholder}}` · L11 narrowed update
+rescue · title `phx-debounce` · canonical/302 query-string preservation · reserved route
+words on post/group slugs.
 
-## Surfaced for your decision — NOT changed
+**H7 (boss-approved):** removed `<Hero>`/`<Page>` — they resolved to core modules deleted
+with the Pages module (core 0fc3de09).
 
-These are real findings I deliberately did not fix autonomously (out of scope,
-invasive, a product decision, or environment-specific). Each needs your call.
+**Docs:** unique-index TODO in this `AGENTS.md`; signed file-URL hardening note in core
+`AGENTS.md`.
 
-- **M4 — publish atomicity.** `update_version_defaults` can commit
-  `status="published"` while the paired `Versions.publish_version` (separate
-  transaction) rolls back, leaving published-with-no-active-version (admin shows
-  published, public 404s). Fixing it means either making publish atomic
-  (restructuring the publish flow) or adding a StaleFixer demotion rule — both
-  carry real risk of breaking publish. Recommend we pair on the approach.
-- **M5 — per-post SEO/OG overrides are write-only.** `params["seo"]` is persisted
-  but `get_seo` has no readers and `build_metadata`/`build_og_data` never expose
-  it, so stored `og_title/og_description/og_image` overrides never render. This is
-  a half-built *feature* (not a regression); wiring the read side is functionality
-  to add, so it's your call whether to finish or drop it.
-- **M7 / M14 — clustered-deploy only.** No cross-node cache invalidation (the
-  `:cache_changed` PubSub handler is a no-op), and `PresenceHelpers` calls
-  `Process.alive?/1` on possibly-remote pids (raises on 2+ nodes). N/A for
-  single-node hosting; fix if/when we cluster.
-- **M9 design parts.** Beyond the race fix: the empty-post deletion is a *hard*
-  delete on the *read* path (the code's stated rationale is avoiding a
-  restore→trash loop), `content_empty?` ignores `version.data` (a
-  featured-image-only version counts as empty), and it writes no ActivityLog /
-  cache invalidation. Whether to trash-instead-of-delete and/or move it to a
-  batch pass is a design decision.
-- **M13 remaining.** No DB unique index backs `url_slug` (adding one is a **core**
-  migration); the read-path auto-renamer is newest-wins with no previous-slug
-  record; and `validate_url_slug` doesn't reject claiming another post's previous
-  slug (now that H2 makes previous slugs real, this can hijack 301 traffic).
-- **H7 — `<Hero>`/`<Page>` components don't exist.** The PageBuilder resolves them
-  to `Shared.Components.{Page,Hero}`, which core doesn't ship, so every `<Hero>`
-  block renders an error div. Decision: ship the components in **core** or cut the
-  resolver clauses + spec sections here.
-- **Core-side (`phoenix_kit`) signed-file URLs.** Tokens are 16-bit, never expire
-  (the "expired token" message is false), `/api/files/:uuid/info` hands out valid
-  signed URLs for any uuid, and a nil `secret_key_base` degrades to a predictable
-  no-secret hash. Low impact for public post images; out of scope for this module.
-- **Remaining Lows (L2–L12) + nits.** e.g. preview swallows a save failure (L2);
-  pre-lock read in `do_unpublish_post` (L3); non-transactional blank-version
-  creation (L4); timestamp timezone inconsistency between create vs edit (L5);
-  group-slug rename doesn't invalidate the old cache entry (L6); double-backtick /
-  blockquoted-fence code spans aren't masked from component detection (L8);
-  per-save `:persistent_term` churn / GC pressure (L12); `should_create_new_version?`
-  hardcoded `false`; dead preview-token feature. Happy to work through these in a
-  follow-up pass — flagging rather than parking them.
+## Surfaced — NOT changed (your call)
+
+- **L5 — timestamp timezone inconsistency.** Creation stamps UTC, but editing
+  `published_at` (a `datetime-local` input) appends `:00Z`, treating the browser's local
+  wall-clock as UTC (`forms.ex` ~159). Created vs edited posts can disagree about which
+  day they live under. The correct fix needs the browser's TZ offset (or sending UTC from
+  the client) — a real design decision, and a rushed timezone change risks making it
+  worse. Recommend we decide the canonical behavior together.
+- **L7 — re-enabling the memory cache can serve pre-disable data.** While disabled, reads
+  already return `:cache_miss` (no stale serve); the gap is the brief window after
+  re-enabling before regeneration, since old `:persistent_term` entries were never erased.
+  Fixing it well means erasing across all groups on toggle (not trivially enumerable) —
+  worth a small dedicated change, not a tail-of-session patch.
+- **L10 — stale-lock takeover can be undone by a slow original holder.** The lock's
+  `after: :ets.delete` is unconditional, so a slow original holder can delete the
+  taker's lock → a brief *duplicate* regeneration (the reviewer confirmed: not
+  corruption). Fixing it cleanly needs a per-acquisition lock token.
+- **L12 — `:persistent_term` write churn.** Every save rebuilds the listing term + writes
+  two always-changing timestamp terms, and each `:persistent_term.put` triggers a global
+  GC pass — recurring whole-VM pause pressure with large listings + autosave traffic. The
+  cheap win is folding the timestamps into the posts term; it's a perf refactor that only
+  bites at scale.
+- **M13 inline cross-post slug edit** — the conflict modal names + links the other post;
+  editing *its* slug from inside the modal (cross-post mutation: its version, its previous-
+  slug recording, its cache, concurrent-edit handling) is a tracked follow-up.
+- **M13 #1 / core signed-URLs** — documented as TODOs (publishing + core `AGENTS.md`),
+  both needing a migration / core changes.
+
+Each of the four Lows above is a deliberate "surface, don't rush" — say the word on any
+and I'll do it as a focused change with its own tests.

--- a/dev_docs/pull_requests/2026/13-issue-11-resolver/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/13-issue-11-resolver/FOLLOW_UP.md
@@ -14,21 +14,22 @@ codebase-shape observations — no findings tagged HIGH or MEDIUM.
   then `read_post_by_uuid` → `resolve_language_to_dialect/1` against
   enabled languages. Closes follow-up #2 from the review.
 
-## Skipped (with rationale)
+## Fixed (pre-existing — verified 2026-06-11)
 
-- **#1 (codebase-shape) — Unify the three base→dialect resolvers**
-  (`Posts.enabled_dialect_for_base/2`,
-  `Web.Controller.Language.find_dialect_for_base/2`,
-  `Web.Controller.Language.resolve_language_for_post/2`). The
-  reviewer framed this as "~1 hour when next touching either
-  layer." Deferred to its own PR because: (a) the helpers operate
-  at different abstraction levels (one is a higher-level wrapper
-  around another), (b) `enabled_dialect_for_base/2`'s primary
-  tie-break does a DB-cached read (`LanguageHelpers.get_primary_language/0`)
-  that's a side effect baked into the helper — purely-functional
-  extraction needs more thought, and (c) the divergence is now
-  documented in the AGENTS.md flow diagram so the next contributor
-  knows it exists. Not blocking; not a live bug.
+- **#1 — Unify the three base→dialect resolvers.** Done in a later PR.
+  The shared resolver is now `LanguageHelpers.resolve_dialect_for_base/3`
+  (`lib/phoenix_kit_publishing/language_helpers.ex:392`), whose `opts`
+  carry the tie-break as `prefer:` (primary-language preference) /
+  `exclude:` — exactly the `resolve_in/3` + `:tie_break` shape the review
+  envisioned. Both context entry points delegate to it:
+  `Posts.resolve_language_to_dialect/1` (`posts.ex:840`, `prefer:` =
+  primary) and `Web.Controller.Language.find_dialect_for_base/2`
+  (`language.ex:269`, no prefer = first-match), plus `StaleFixer`
+  (`stale_fixer.ex:543`). The DB-cached primary read is lifted out and
+  passed in as the `prefer:` opt by the caller, so the side effect no
+  longer lives in the helper. The duplication is gone; the remaining
+  two thin wrappers are just context-specific callers of one shared
+  helper with different opts — the desired end state.
 
 ## Files touched
 
@@ -38,10 +39,10 @@ codebase-shape observations — no findings tagged HIGH or MEDIUM.
 
 ## Verification
 
-- `AGENTS.md` content review only. No code edits in this sweep.
+- 2026-05-18: `AGENTS.md` content review only. No code edits in that sweep.
+- 2026-06-11: re-verified `#1` is resolved by `resolve_dialect_for_base/3`
+  (source-read of `posts.ex:840`, `language.ex:269`, `stale_fixer.ex:543`).
 
 ## Open
 
-- **#1** — Unify the three base→dialect resolvers into a single
-  `Languages.resolve_in/3` with an explicit `:tie_break` opt. Wants
-  its own focused PR with test verification.
+None.

--- a/dev_docs/pull_requests/2026/15-language-switcher-host-integration/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/15-language-switcher-host-integration/FOLLOW_UP.md
@@ -34,48 +34,55 @@ Re-verified 2026-05-18 — both closures present in
   — "worst of both worlds" per the reviewer). Now snapshots each
   setting's prior value at setup and restores all five in `on_exit`.
 
+## Fixed (Batch 2 — 2026-06-11)
+
+- **Controller render-branch consolidation.** The four public render
+  branches (`handle_group_listing` / `handle_post` /
+  `handle_versioned_post` / `handle_date_only_url`) each repeated the
+  same `assign(:translations, …)` + `assign_publishing_translations/2` +
+  `assign(:show_language_switcher, …)` block. Extracted into
+  `assign_publishing_render_context/2` (`web/controller.ex`); all four
+  branches now call it, so the block can't drift across branches.
+- **Date-only route coverage.** Added a render test for the
+  previously-uncovered date-only branch
+  (`language_switcher_exposure_test.exs` — "render-context assigns on
+  every public branch") that seeds a timestamp-mode post and asserts
+  `:phoenix_kit_publishing_translations` + `:show_language_switcher`
+  land. With the listing + post branches already covered, that's 3 of 4
+  render branches pinned at the integration level; the versioned
+  (`/v/N`) branch calls the identical helper but only renders with
+  `allow_version_access` enabled, so it's covered by code identity.
+
 ## Skipped (with rationale)
 
-- **Positive-render assertion with multi-language fixture** — the
-  reviewer noted the existing positive case only checks the conn
-  assign (not the rendered HTML) because the fixture is
-  single-language and the switcher is also gated on
-  `length(@translations) > 1`. Setting up a true multi-language
-  fixture means seeding language settings + creating per-language
-  translations on the post, which is non-trivial for one assertion.
-  Defer to a focused test-coverage pass.
-- **Coverage on versioned (`/v/N`) + date-only routes** — the
-  PR added the assign at 4 controller call sites; current tests
-  cover 2 (group-listing + post). The other two routes are
-  identical copy-paste of the same `assign_publishing_translations`
-  + `:show_language_switcher` block, so the drift risk is real but
-  modest. Defer to the same test-coverage pass.
-- **Replace `class="language-switcher"` CSS-class marker with a
-  refactor-resilient `data-testid`** — the marker lives on
-  `<.language_switcher_dropdown>` in phoenix_kit core, so the fix
-  is cross-repo. Not worth the cross-repo edit for a single
-  refute-marker.
-- **Refactor four near-identical controller render branches into a
-  shared `assign_publishing_render_context/2` helper** — out of
-  scope per the reviewer ("different PR").
+- **Multi-language in-page positive render** — the "host-integration
+  boundary" describe block already renders multi-language
+  (`languages_enabled: true`) and asserts the host layout's nav
+  `data-count` matches the controller's translation count, so the
+  positive multi-lang *forwarding* is pinned. Asserting the *in-page*
+  switcher HTML specifically is blocked by the test harness: the stand-in
+  `Test.Layouts.app/1` only surfaces layout chrome, not the publishing
+  template's inner content where the in-page switcher renders (same
+  limitation documented for OG tags). Not a code gap.
+- **`class="language-switcher"` marker → `data-testid`** — the marker
+  lives on core's `<.language_switcher_dropdown>`, so the fix is
+  cross-repo. Out of scope for a publishing-only sweep; not worth the
+  cross-repo edit for a single refute-marker.
 
 ## Files touched
 
 | File | Change |
 |---|---|
-| `test/phoenix_kit_publishing/web/controller/language_switcher_exposure_test.exs` | Snapshot 5 mutated settings in `setup`; restore all five in `on_exit` (was: only 1 reset) |
+| `test/phoenix_kit_publishing/web/controller/language_switcher_exposure_test.exs` | (Batch 1) settings snapshot/restore in setup; (Batch 2) date-only render-context coverage |
+| `lib/phoenix_kit_publishing/web/controller.ex` | (Batch 2) extract `assign_publishing_render_context/2`; all four render branches call it |
 
 ## Verification
 
-- Test file format / structure review only. `mix test` not re-run
-  in this sweep; the change is purely additive to the lifecycle
-  (no test bodies modified).
+- Batch 1 (2026-05-18): test lifecycle review only.
+- Batch 2 (2026-06-11): `mix compile --warnings-as-errors`, full
+  controller suite (125 tests) + `language_switcher_exposure_test`
+  (8 tests) green after the consolidation.
 
 ## Open
 
-- Test-coverage extension: positive-render with multi-language
-  fixture; versioned + date-only route coverage.
-- Refactor 4 near-identical controller render branches into a
-  shared assign helper (separate PR per reviewer).
-- CSS-class marker → `data-testid` (cross-repo with phoenix_kit
-  core's `<.language_switcher_dropdown>`).
+None.

--- a/dev_docs/pull_requests/2026/24-editor-public-rendering-sweep/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/24-editor-public-rendering-sweep/FOLLOW_UP.md
@@ -1,0 +1,45 @@
+# PR #24 — Phase 1 follow-up (review catch-up)
+
+After-action report for the Phase 1 pass on the PR #24 review
+(`CLAUDE_REVIEW.md`, read-only). Picked up when the merge landed via a
+`pull --rebase`. All work is local commits; nothing pushed. Suite
+**1137 tests, 0 failures**; `mix format`, `mix credo --strict`,
+`mix dialyzer` clean.
+
+## Fixed (with regression tests)
+
+- **#1 — `humanize_field/1` lowercased acronyms** (`errors.ex`). It ran
+  `String.capitalize/1` over the whole field name, so `:url_slug` →
+  "Url slug" and `:seo_title` → "Seo title" in flash messages. Now splits
+  on `_`, uppercases known acronyms (`url`/`seo`/`og`/…), and sentence-cases
+  the first word — "URL slug", "SEO title", while "active_version_uuid" still
+  reads "Active version". Test in `errors_test.exs`.
+- **#3 — slug-truncation warning wiped by the next keystroke** (`forms.ex`).
+  `update_meta` clear_flash's up front, but `maybe_warn_slug_truncated` only
+  put the warning on the false→true transition — so any further keystroke
+  while the slug was still truncated dropped it. Now re-asserts the warning
+  whenever the title is over the URL cap (clears when it shrinks back). LV
+  test in `editor_live_test.exs`.
+- **#4 — brittle test assertion** (`editor_live_test.exs`). Dropped
+  `assert html =~ "does not exist"`, which coupled the test to PostgreSQL's
+  FK-error wording; the neighbouring `assert "save this post."` /
+  `refute "Failed to save post"` already prove the descriptive-flash behaviour.
+
+## Evaluated — left as-is (intentional)
+
+- **#2 — in-page OpenGraph defaults on.** Reviewer flagged that a host which
+  *also* renders the forwarded `:og` in its own `<head>` emits duplicate
+  og/twitter tags until it flips `publishing_render_og_tags`. Kept default-on:
+  the common case is a host with no OG handling, which gets correct social
+  previews out of the box; defaulting off would silently strip OG/Twitter tags
+  from every vanilla CMS install to protect an advanced host that already has
+  a one-toggle opt-out (documented in `AGENTS.md`). One-line flip if we ever
+  want strict opt-in.
+
+The review's one real bug (#1 in `CLAUDE_REVIEW.md` — `safe_to_string/1`
+rescue too narrow) was already fixed in the merge itself (`c6a6754`), with its
+own regression test.
+
+## Open
+
+None.

--- a/lib/phoenix_kit_publishing/db_storage.ex
+++ b/lib/phoenix_kit_publishing/db_storage.ex
@@ -627,11 +627,12 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage do
   share the same custom `url_slug` (the DB has no unique index on content
   url_slug across posts; the per-post `(group_uuid, slug)` index only
   prevents post-slug collisions), the query is allowed to return multiple
-  rows. The newest post wins (`order_by [desc: p.uuid]`, exploiting
+  rows. The OLDEST (incumbent) post wins (`order_by [asc: p.uuid]`, exploiting
   UUIDv7's monotonic timestamp encoding — see schema docs for
-  `PublishingPost`); every loser's `url_slug` is auto-renamed with a
-  `-2`, `-3`, … suffix so the next request resolves cleanly without
-  crashing on `Ecto.MultipleResultsError`. This is a **best-effort**
+  `PublishingPost`) so the post that owned the slug first keeps its URL; every
+  newer loser's `url_slug` is auto-renamed with a `-2`, `-3`, … suffix so the
+  next request resolves cleanly without crashing on
+  `Ecto.MultipleResultsError`. This is a **best-effort**
   self-healing safety net for collisions that get past the
   application-level uniqueness check in
   `PhoenixKit.Modules.Publishing.SlugHelpers`, not a transactional
@@ -711,6 +712,41 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage do
     repo().exists?(query)
   end
 
+  @doc """
+  Returns true if `url_slug` is a PREVIOUS slug of another published post in the
+  group+language (i.e. a slug that post's 301 redirect still owns). A new post
+  claiming it would shadow that redirect — current-slug lookup wins over
+  previous-slug lookup — so old URLs would land on the new post instead. M13.
+  """
+  @spec previous_url_slug_taken_by_other_post?(
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t() | nil
+        ) ::
+          boolean()
+  def previous_url_slug_taken_by_other_post?(group_slug, language, url_slug, exclude_post_slug) do
+    base =
+      from(c in PublishingContent,
+        join: v in assoc(c, :version),
+        join: p in assoc(v, :post),
+        join: g in assoc(p, :group),
+        where:
+          g.slug == ^group_slug and c.language == ^language and
+            is_nil(p.trashed_at) and v.uuid == p.active_version_uuid and
+            fragment("? @> ?", c.data, ^%{"previous_url_slugs" => [url_slug]})
+      )
+
+    query =
+      if is_binary(exclude_post_slug) and exclude_post_slug != "" do
+        from([c, v, p, g] in base, where: p.slug != ^exclude_post_slug)
+      else
+        base
+      end
+
+    repo().exists?(query)
+  end
+
   # Published-only custom-slug match — returns ALL matches so the caller
   # can apply the tie-breaker. Ordering by `p.uuid DESC` exploits UUIDv7's
   # monotonic timestamp encoding: the newest post sorts first without
@@ -724,7 +760,10 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage do
       where:
         g.slug == ^group_slug and c.language == ^language and c.url_slug == ^url_slug and
           is_nil(p.trashed_at) and v.uuid == p.active_version_uuid,
-      order_by: [desc: p.uuid],
+      # asc: the OLDEST (incumbent) post wins and keeps its established URL; any
+      # newer post that collided is the loser and gets auto-renamed. Never silently
+      # change the URL of the post that owned the slug first.
+      order_by: [asc: p.uuid],
       preload: [version: {v, post: {p, group: g}}]
     )
     |> repo().all()

--- a/lib/phoenix_kit_publishing/db_storage.ex
+++ b/lib/phoenix_kit_publishing/db_storage.ex
@@ -207,6 +207,27 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage do
     end
   end
 
+  @doc """
+  Returns true if the `(group, date, minute)` timestamp slot is occupied by ANY
+  post — including trashed ones.
+
+  `get_post_by_datetime/3` filters out trashed posts (correct for serving), but
+  the unique index on `(group_uuid, post_date, post_time)` includes them (to
+  protect restore). So availability probes must see trashed rows too, otherwise a
+  trashed post's slot looks free, the insert hits the index, and the collision
+  retry can never resolve it.
+  """
+  @spec timestamp_slot_taken?(String.t(), Date.t(), Time.t()) :: boolean()
+  def timestamp_slot_taken?(group_slug, date, time) do
+    normalized_time = %Time{hour: time.hour, minute: time.minute, second: 0, microsecond: {0, 0}}
+
+    from(p in PublishingPost,
+      join: g in assoc(p, :group),
+      where: g.slug == ^group_slug and p.post_date == ^date and p.post_time == ^normalized_time
+    )
+    |> repo().exists?()
+  end
+
   @doc "Gets a post by UUID with preloads."
   @spec get_post_by_uuid(String.t(), list(atom() | tuple())) :: PublishingPost.t() | nil
   def get_post_by_uuid(uuid, preloads \\ []) do

--- a/lib/phoenix_kit_publishing/db_storage/mapper.ex
+++ b/lib/phoenix_kit_publishing/db_storage/mapper.ex
@@ -170,6 +170,8 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage.Mapper do
       description: nil,
       status: status,
       slug: nil,
+      # No version → no version-history access.
+      allow_version_access: false,
       published_at: nil,
       featured_image_uuid: nil
     }
@@ -181,6 +183,9 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage.Mapper do
       description: PublishingVersion.get_description(version),
       status: status,
       slug: post.slug,
+      # Must mirror build_metadata/4 — the public version dropdown reads this
+      # from the cached listing map; omitting it hid the dropdown on a warm cache.
+      allow_version_access: PublishingVersion.get_allow_version_access(version),
       published_at: format_datetime(version.published_at),
       featured_image_uuid: PublishingVersion.get_featured_image_uuid(version)
     }
@@ -192,6 +197,8 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage.Mapper do
       description: PublishingVersion.get_description(version),
       status: status,
       slug: post.slug,
+      # Must mirror build_metadata/4 — see the clause above.
+      allow_version_access: PublishingVersion.get_allow_version_access(version),
       published_at: format_datetime(version.published_at),
       featured_image_uuid: PublishingVersion.get_featured_image_uuid(version)
     }

--- a/lib/phoenix_kit_publishing/errors.ex
+++ b/lib/phoenix_kit_publishing/errors.ex
@@ -208,16 +208,26 @@ defmodule PhoenixKit.Modules.Publishing.Errors do
     _ -> inspect(value)
   end
 
-  # "active_version_uuid" -> "Active version" — strip the internal *_uuid
-  # suffix and underscores so we don't surface raw column names to users.
+  # Acronyms kept fully uppercased — plain String.capitalize/1 would downcase
+  # them to "Url slug" / "Seo title".
+  @field_acronyms ~w(url seo og ai id api ip html css uuid)
+
+  # "active_version_uuid" -> "Active version"; "url_slug" -> "URL slug" — strip
+  # the internal *_uuid suffix, split on underscores, uppercase known acronyms,
+  # and sentence-case the first word so we surface neither raw column names nor
+  # lowercased acronyms to users.
   defp humanize_field(field) do
     field
     |> to_string()
     |> String.replace_suffix("_uuid", "")
-    |> String.replace("_", " ")
-    |> String.trim()
-    |> String.capitalize()
+    |> String.split("_", trim: true)
+    |> Enum.with_index()
+    |> Enum.map_join(" ", &humanize_word/1)
   end
+
+  defp humanize_word({word, _idx}) when word in @field_acronyms, do: String.upcase(word)
+  defp humanize_word({word, 0}), do: String.capitalize(word)
+  defp humanize_word({word, _idx}), do: word
 
   @doc """
   Renders any error reason as a log-safe string clipped to `max` chars.

--- a/lib/phoenix_kit_publishing/groups.ex
+++ b/lib/phoenix_kit_publishing/groups.ex
@@ -226,6 +226,10 @@ defmodule PhoenixKit.Modules.Publishing.Groups do
              {:ok, sanitized_slug} <- extract_and_validate_slug(db_group, params, name),
              {:ok, updated} <-
                DBStorage.update_group(db_group, %{name: name, slug: sanitized_slug}) do
+          # A slug rename orphans the old slug's listing cache entry — it leaks in
+          # :persistent_term and keeps serving stale data under the old key (L6).
+          if db_group.slug != updated.slug, do: ListingCache.invalidate(db_group.slug)
+
           group = db_group_to_map(updated)
           PublishingPubSub.broadcast_group_updated(group)
 

--- a/lib/phoenix_kit_publishing/listing_cache.ex
+++ b/lib/phoenix_kit_publishing/listing_cache.ex
@@ -312,8 +312,15 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
     :ets.delete(@lock_table, group_slug)
   end
 
-  # Ensure the ETS table for locks exists (lazy initialization)
-  defp ensure_lock_table_exists do
+  # Ensure the ETS table for locks exists (lazy initialization).
+  #
+  # Public so a supervised owner (LockTableOwner) can create it at startup. The
+  # table is otherwise born in whichever transient request process first misses
+  # the cache, and dies with that process — after which the lock ops here raise
+  # ArgumentError on the vanished table and 500 a public read (M8). The lazy path
+  # stays as a fallback for the brief window before/around an owner restart.
+  @doc false
+  def ensure_lock_table_exists do
     case :ets.whereis(@lock_table) do
       :undefined ->
         # Table doesn't exist - create it

--- a/lib/phoenix_kit_publishing/listing_cache.ex
+++ b/lib/phoenix_kit_publishing/listing_cache.ex
@@ -47,7 +47,6 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
   require Logger
 
   @persistent_term_prefix :phoenix_kit_group_listing_cache
-  @persistent_term_loaded_at_prefix :phoenix_kit_group_listing_cache_loaded_at
   @persistent_term_cache_generated_at_prefix :phoenix_kit_group_listing_cache_generated_at
 
   # ETS table for regeneration locks (provides atomic test-and-set via insert_new)
@@ -186,8 +185,10 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
 
     generated_at = UtilsDate.utc_now() |> DateTime.to_iso8601()
 
+    # Two puts, not three: the loaded-at and generated-at timestamps were always
+    # written with the SAME value, and each :persistent_term.put triggers a global
+    # GC pass — wasteful under autosave traffic. Store the timestamp once (L12).
     safe_persistent_term_put(persistent_term_key(group_slug), posts)
-    safe_persistent_term_put(loaded_at_key(group_slug), generated_at)
     safe_persistent_term_put(cache_generated_at_key(group_slug), generated_at)
 
     elapsed = System.monotonic_time(:millisecond) - start_time
@@ -382,7 +383,6 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
     generated_at = UtilsDate.utc_now() |> DateTime.to_iso8601()
 
     safe_persistent_term_put(persistent_term_key(group_slug), posts)
-    safe_persistent_term_put(loaded_at_key(group_slug), generated_at)
     safe_persistent_term_put(cache_generated_at_key(group_slug), generated_at)
 
     Logger.debug(
@@ -416,18 +416,39 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
     end
 
     try do
-      :persistent_term.erase(loaded_at_key(group_slug))
-    rescue
-      ArgumentError -> :ok
-    end
-
-    try do
       :persistent_term.erase(cache_generated_at_key(group_slug))
     rescue
       ArgumentError -> :ok
     end
 
     Logger.debug("[ListingCache] Invalidated cache for #{group_slug}")
+    :ok
+  end
+
+  @doc """
+  Erases EVERY listing-cache `:persistent_term` entry (all groups, this node).
+
+  Used when memory caching is toggled off, so a later re-enable can't serve
+  pre-disable data — `read/1` returns `:cache_miss` while disabled, but the stale
+  terms would otherwise still be present (under all three prefixes) the moment it's
+  re-enabled. `:persistent_term` has no prefix-scan, so this filters the full term
+  snapshot — fine for a rare admin toggle, never call it on a hot path.
+  """
+  @spec erase_all() :: :ok
+  def erase_all do
+    Enum.each(:persistent_term.get(), fn
+      {{prefix, _slug} = key, _value}
+      when prefix in [@persistent_term_prefix, @persistent_term_cache_generated_at_prefix] ->
+        try do
+          :persistent_term.erase(key)
+        rescue
+          ArgumentError -> :ok
+        end
+
+      _ ->
+        :ok
+    end)
+
     :ok
   end
 
@@ -649,22 +670,15 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
   end
 
   @doc """
-  Returns the :persistent_term key for tracking when the memory cache was loaded.
-  """
-  @spec loaded_at_key(String.t()) :: tuple()
-  def loaded_at_key(group_slug) do
-    {@persistent_term_loaded_at_prefix, group_slug}
-  end
-
-  @doc """
   Returns when the memory cache was loaded (ISO 8601 string), or nil if not loaded.
+
+  Backed by the same `:persistent_term` entry as `cache_generated_at/1` — on this
+  node the cache is loaded exactly when it's generated, so the two are identical
+  and share one entry (L12).
   """
   @spec memory_loaded_at(String.t()) :: String.t() | nil
   def memory_loaded_at(group_slug) do
-    case safe_persistent_term_get(loaded_at_key(group_slug)) do
-      {:ok, loaded_at} -> loaded_at
-      :not_found -> nil
-    end
+    cache_generated_at(group_slug)
   end
 
   @doc """

--- a/lib/phoenix_kit_publishing/listing_cache.ex
+++ b/lib/phoenix_kit_publishing/listing_cache.ex
@@ -81,7 +81,13 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
         hit
 
       :not_found ->
-        regenerate(group_slug)
+        # Go through the in-progress guard, not `regenerate/1` directly, so a
+        # burst of concurrent misses (e.g. right after a restart) doesn't fire
+        # N synchronous regenerations + N global `:persistent_term.put` GCs.
+        # A loser sees `:already_in_progress`, reads an as-yet-empty term, and
+        # returns `:cache_miss` — which every caller already handles with a
+        # direct DB read (see PostFetching.handle_cache_miss/2).
+        regenerate_if_not_in_progress(group_slug)
         read_after_regenerate(term_key)
     end
   end

--- a/lib/phoenix_kit_publishing/listing_cache.ex
+++ b/lib/phoenix_kit_publishing/listing_cache.ex
@@ -234,13 +234,17 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
   def regenerate_if_not_in_progress(group_slug) do
     ensure_lock_table_exists()
     now = System.monotonic_time(:millisecond)
+    # Unique per-acquisition token so release only removes OUR lock, never a
+    # takeover holder's that replaced it (L10). The value is {timestamp, token}:
+    # timestamp drives staleness, token drives ownership.
+    token = make_ref()
 
     # Try to atomically acquire the lock using ETS insert_new
     # Returns true if inserted (lock acquired), false if key already exists
-    case :ets.insert_new(@lock_table, {group_slug, now}) do
+    case :ets.insert_new(@lock_table, {group_slug, {now, token}}) do
       true ->
         # We acquired the lock - perform regeneration
-        do_regenerate_with_lock(group_slug)
+        do_regenerate_with_lock(group_slug, token)
 
       false ->
         # Lock exists - check if it's stale
@@ -260,7 +264,7 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
   # Handle case where lock already exists - check staleness
   defp handle_existing_lock(group_slug, now) do
     case :ets.lookup(@lock_table, group_slug) do
-      [{^group_slug, lock_timestamp}] ->
+      [{^group_slug, {lock_timestamp, _token} = lock_value}] ->
         lock_age = now - lock_timestamp
 
         if lock_age < @lock_timeout_ms do
@@ -273,7 +277,7 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
         else
           # Lock is stale - previous process likely died
           # Try to take over by deleting and re-acquiring atomically
-          take_over_stale_lock(group_slug, lock_timestamp, lock_age, now)
+          take_over_stale_lock(group_slug, lock_value, lock_age, now)
         end
 
       [] ->
@@ -283,19 +287,21 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
   end
 
   # Attempt to take over a stale lock using compare-and-delete
-  defp take_over_stale_lock(group_slug, old_timestamp, lock_age, now) do
-    # Use match_delete for atomic compare-and-delete
-    # Only deletes if the timestamp matches (no one else took over)
-    case :ets.select_delete(@lock_table, [{{group_slug, old_timestamp}, [], [true]}]) do
+  defp take_over_stale_lock(group_slug, stale_value, lock_age, now) do
+    # Atomic compare-and-delete: only deletes if the exact {timestamp, token}
+    # is still present (no one else already took over).
+    case :ets.select_delete(@lock_table, [{{group_slug, stale_value}, [], [true]}]) do
       1 ->
-        # Successfully deleted stale lock - now try to acquire
+        # Successfully deleted stale lock - now try to acquire with a fresh token
         Logger.warning(
           "[ListingCache] Found stale lock for #{group_slug} (#{lock_age}ms old), taking over regeneration"
         )
 
-        case :ets.insert_new(@lock_table, {group_slug, now}) do
+        token = make_ref()
+
+        case :ets.insert_new(@lock_table, {group_slug, {now, token}}) do
           true ->
-            do_regenerate_with_lock(group_slug)
+            do_regenerate_with_lock(group_slug, token)
 
           false ->
             # Another process beat us to it
@@ -309,7 +315,7 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
   end
 
   # Perform regeneration while holding the lock
-  defp do_regenerate_with_lock(group_slug) do
+  defp do_regenerate_with_lock(group_slug, token) do
     result = regenerate(group_slug)
 
     case result do
@@ -317,8 +323,11 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
       {:error, _} = error -> error
     end
   after
-    # Always release the lock when done (success or failure)
-    :ets.delete(@lock_table, group_slug)
+    # Release ONLY our own lock. Deleting by key alone would wipe a takeover
+    # holder's lock if our regeneration ran long and another process replaced us
+    # (with a new token) — letting a duplicate regeneration start (L10). The
+    # token match makes the release a no-op once we've been superseded.
+    :ets.select_delete(@lock_table, [{{group_slug, {:_, token}}, [], [true]}])
   end
 
   # Ensure the ETS table for locks exists (lazy initialization).

--- a/lib/phoenix_kit_publishing/listing_cache.ex
+++ b/lib/phoenix_kit_publishing/listing_cache.ex
@@ -246,6 +246,15 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache do
         # Lock exists - check if it's stale
         handle_existing_lock(group_slug, now)
     end
+  rescue
+    ArgumentError ->
+      # The lock table vanished mid-operation — e.g. a transient process recreated
+      # it during a LockTableOwner restart gap and then died. A public read must
+      # never 500 over this; recreate the table and report "in progress" so the
+      # caller falls back to a direct DB read (a harmless extra regeneration at
+      # worst). Backstop for the supervised-owner fix (M8).
+      ensure_lock_table_exists()
+      :already_in_progress
   end
 
   # Handle case where lock already exists - check staleness

--- a/lib/phoenix_kit_publishing/listing_cache/lock_table_owner.ex
+++ b/lib/phoenix_kit_publishing/listing_cache/lock_table_owner.ex
@@ -1,0 +1,28 @@
+defmodule PhoenixKit.Modules.Publishing.ListingCache.LockTableOwner do
+  @moduledoc """
+  Long-lived owner for the `ListingCache` regeneration-lock ETS table.
+
+  The lock table is `:public`/`:named_table`, but ETS tables are owned by the
+  process that creates them. Without a supervised owner it was born in whichever
+  transient request process first missed the cache and died with that process —
+  after which the lock operations raised `ArgumentError` on the vanished table and
+  500'd a public read (M8). Creating it from this supervised GenServer keeps it
+  alive for the life of the node; on the rare crash/restart the supervisor brings
+  the owner (and table) back, and `ListingCache.ensure_lock_table_exists/0` covers
+  the brief gap.
+  """
+
+  use GenServer
+
+  alias PhoenixKit.Modules.Publishing.ListingCache
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, :ok, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(:ok) do
+    ListingCache.ensure_lock_table_exists()
+    {:ok, %{}}
+  end
+end

--- a/lib/phoenix_kit_publishing/metadata.ex
+++ b/lib/phoenix_kit_publishing/metadata.ex
@@ -124,7 +124,6 @@ defmodule PhoenixKit.Modules.Publishing.Metadata do
 
   defp extract_title_from_components(content) do
     component_title(content, "Headline") ||
-      component_attribute(content, "Hero", "title") ||
       component_title(content, "Title")
   end
 
@@ -133,15 +132,6 @@ defmodule PhoenixKit.Modules.Publishing.Metadata do
 
     case Regex.run(regex, content, capture: :all_but_first) do
       [inner | _] -> sanitize_component_text(inner)
-      _ -> nil
-    end
-  end
-
-  defp component_attribute(content, tag, attr) do
-    regex = ~r/<#{tag}\b[^>]*#{attr}="([^"]+)"[^>]*>/i
-
-    case Regex.run(regex, content, capture: :all_but_first) do
-      [value | _] -> sanitize_component_text(value)
       _ -> nil
     end
   end

--- a/lib/phoenix_kit_publishing/page_builder.ex
+++ b/lib/phoenix_kit_publishing/page_builder.ex
@@ -76,10 +76,15 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder do
 
   defp inject_assigns(value, _assigns), do: value
 
-  # Interpolate {{variable}} placeholders
+  # Interpolate {{variable}} placeholders. An unresolved placeholder (no value in
+  # assigns) is left AS-IS — replacing it with "" silently deletes author-written
+  # braces when content is rendered without data (L9, content loss).
   defp interpolate_string(string, assigns) do
-    Regex.replace(~r/\{\{([^}]+)\}\}/, string, fn _, path ->
-      get_nested_value(assigns, String.trim(path)) |> to_string()
+    Regex.replace(~r/\{\{([^}]+)\}\}/, string, fn full_match, path ->
+      case get_nested_value(assigns, String.trim(path)) do
+        nil -> full_match
+        value -> to_string(value)
+      end
     end)
   end
 

--- a/lib/phoenix_kit_publishing/page_builder/parser.ex
+++ b/lib/phoenix_kit_publishing/page_builder/parser.ex
@@ -4,31 +4,17 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.Parser do
 
   Example input:
   ```xml
-  <Page slug="home">
-    <Hero variant="split-image">
-      <Headline>Welcome to PhoenixKit</Headline>
-      <Subheadline>Build faster with {{framework}}</Subheadline>
-      <CTA primary="true" action="/signup">Get Started</CTA>
-    </Hero>
-  </Page>
+  <Headline>Welcome to PhoenixKit</Headline>
+  <Subheadline>Build faster with {{framework}}</Subheadline>
+  <CTA primary="true" action="/signup">Get Started</CTA>
   ```
 
-  Output AST:
+  Output AST (one node per top-level element):
   ```elixir
   %{
-    type: :page,
-    attributes: %{slug: "home"},
-    children: [
-      %{
-        type: :hero,
-        attributes: %{variant: "split-image"},
-        children: [
-          %{type: :headline, content: "Welcome to PhoenixKit"},
-          %{type: :subheadline, content: "Build faster with {{framework}}"},
-          %{type: :cta, attributes: %{primary: "true", action: "/signup"}, content: "Get Started"}
-        ]
-      }
-    ]
+    type: :headline,
+    attributes: %{},
+    content: "Welcome to PhoenixKit"
   }
   ```
   """
@@ -136,7 +122,7 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.SaxHandler do
     {:ok, state}
   end
 
-  # Normalize tag names to atoms (Page -> :page, Hero -> :hero).
+  # Normalize tag names to atoms (Headline -> :headline, CTA -> :cta).
   #
   # Uses `String.to_existing_atom/1` so user-supplied (admin-edited) PHK
   # XML content can't keep minting new atoms — the BEAM atom table is
@@ -146,9 +132,9 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.SaxHandler do
   #
   # The atoms for legitimate PHK components are pre-allocated at compile
   # time by their resolver clauses in
-  # `PhoenixKit.Modules.Publishing.PageBuilder.Renderer` (`:page`,
-  # `:hero`, `:headline`, `:subheadline`, `:cta`, `:image`, `:video`,
-  # `:entityform`), so `String.to_existing_atom/1` finds them. New
+  # `PhoenixKit.Modules.Publishing.PageBuilder.Renderer` (`:headline`,
+  # `:subheadline`, `:cta`, `:image`, `:video`, `:entityform`), so
+  # `String.to_existing_atom/1` finds them. New
   # components added in the future must ship a matching resolver clause
   # to register their atom — same as today.
   defp normalize_tag_name(name) do

--- a/lib/phoenix_kit_publishing/page_builder/renderer.ex
+++ b/lib/phoenix_kit_publishing/page_builder/renderer.ex
@@ -33,9 +33,8 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.Renderer do
     {:ok, Phoenix.HTML.raw(content)}
   end
 
-  # Resolve component type to module
-  defp resolve_component(:page), do: {:ok, PhoenixKit.Modules.Shared.Components.Page}
-  defp resolve_component(:hero), do: {:ok, PhoenixKit.Modules.Shared.Components.Hero}
+  # Resolve component type to module. Page/Hero were removed with the Pages module
+  # (see core 0fc3de09); their tags now fall through to the catch-all.
   defp resolve_component(:headline), do: {:ok, PhoenixKit.Modules.Shared.Components.Headline}
 
   defp resolve_component(:subheadline),

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -1230,7 +1230,6 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
       )
       |> maybe_put_version_field("seo_title", Map.get(params, "seo_title"))
       |> maybe_put_version_field("tags", Map.get(params, "tags"))
-      |> maybe_put_version_field("seo", Map.get(params, "seo"))
       |> maybe_put_version_field("excerpt", Map.get(params, "excerpt"))
 
     # Also update version-level status and published_at if provided.

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -624,18 +624,25 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
     end
   end
 
-  # The `(group_uuid, post_date, post_time)` unique-constraint
-  # violation lands here as a changeset error after `repo.rollback`.
-  # Both the field-level and constraint-name keys are checked because
-  # Ecto puts the error under whichever field is declared in the
-  # `unique_constraint/3` call (currently `:post_time`).
+  # The `(group_uuid, post_date, post_time)` unique-constraint violation lands
+  # here as a changeset error after `repo.rollback`. Ecto puts the error under
+  # the FIRST field of the `unique_constraint/3` list — `:group_uuid`, NOT
+  # `:post_time` — so matching only the date/time keys meant this never fired and
+  # concurrent same-minute creates surfaced "Group has already been taken". Match
+  # the constraint NAME (like StaleFixer.slug_conflict?/1) so a real FK error or
+  # the slug-uniqueness violation on the same `:group_uuid` key isn't mistaken
+  # for a timestamp collision.
   defp timestamp_collision?({:error, %Ecto.Changeset{errors: errors}}) do
-    Enum.any?(errors, fn
-      {field, {_msg, opts}} when field in [:post_time, :post_date] ->
-        opts[:constraint] == :unique
+    Enum.any?([:group_uuid, :post_date, :post_time], fn key ->
+      case Keyword.get(errors, key) do
+        {_msg, opts} ->
+          Keyword.get(opts, :constraint) == :unique and
+            Keyword.get(opts, :constraint_name) ==
+              "idx_publishing_posts_group_date_time_unique"
 
-      _ ->
-        false
+        _ ->
+          false
+      end
     end)
   end
 
@@ -862,24 +869,29 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
   end
 
   defp find_available_timestamp(group_slug, date, time, attempts) do
-    case DBStorage.get_post_by_datetime(group_slug, date, time) do
-      nil ->
-        {date, time}
+    # Trashed-INCLUSIVE check: the unique index includes trashed rows, so a
+    # version that only looked at live posts would keep handing back a slot the
+    # DB rejects, and the collision retry could never converge (see M2/M1).
+    if DBStorage.timestamp_slot_taken?(group_slug, date, time) do
+      bump_timestamp(group_slug, date, time, attempts)
+    else
+      {date, time}
+    end
+  end
 
-      _existing ->
-        # Bump by one minute
-        total_seconds = time.hour * 3600 + time.minute * 60 + 60
+  # Advance the candidate timestamp by one minute, rolling over to the next day
+  # at midnight, and retry the availability check.
+  defp bump_timestamp(group_slug, date, time, attempts) do
+    total_seconds = time.hour * 3600 + time.minute * 60 + 60
 
-        if total_seconds >= 86_400 do
-          # Rolled past midnight — advance to next day at 00:00
-          next_date = Date.add(date, 1)
-          find_available_timestamp(group_slug, next_date, ~T[00:00:00], attempts + 1)
-        else
-          next_hour = div(total_seconds, 3600)
-          next_minute = div(rem(total_seconds, 3600), 60)
-          next_time = %Time{hour: next_hour, minute: next_minute, second: 0, microsecond: {0, 0}}
-          find_available_timestamp(group_slug, date, next_time, attempts + 1)
-        end
+    if total_seconds >= 86_400 do
+      next_date = Date.add(date, 1)
+      find_available_timestamp(group_slug, next_date, ~T[00:00:00], attempts + 1)
+    else
+      next_hour = div(total_seconds, 3600)
+      next_minute = div(rem(total_seconds, 3600), 60)
+      next_time = %Time{hour: next_hour, minute: next_minute, second: 0, microsecond: {0, 0}}
+      find_available_timestamp(group_slug, date, next_time, attempts + 1)
     end
   end
 

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -710,7 +710,7 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
   defp read_post_from_db(group_slug, identifier, language, version) do
     # If identifier is a UUID, resolve via UUID lookup (handles both modes)
     if Shared.uuid_format?(identifier) do
-      read_post_by_uuid(identifier, language, version)
+      read_uuid_post_in_group(group_slug, identifier, language, version)
     else
       case Publishing.get_group_mode(group_slug) do
         "timestamp" ->
@@ -719,6 +719,19 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
         _ ->
           read_post_from_db_slug(group_slug, identifier, language, version)
       end
+    end
+  end
+
+  # Pin a UUID lookup to the requested group. read_post_by_uuid/3 resolves purely
+  # by UUID, so without this `GET /<any-group>/<uuid>` would serve a post from a
+  # DIFFERENT group under the wrong group's name + canonical URL (M6).
+  defp read_uuid_post_in_group(group_slug, identifier, language, version) do
+    case read_post_by_uuid(identifier, language, version) do
+      {:ok, post} ->
+        if post[:group] == group_slug, do: {:ok, post}, else: {:error, :not_found}
+
+      other ->
+        other
     end
   end
 

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -25,6 +25,7 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
   alias PhoenixKit.Modules.Publishing.Shared
   alias PhoenixKit.Modules.Publishing.SlugHelpers
   alias PhoenixKit.Modules.Publishing.StaleFixer
+  alias PhoenixKit.Settings
   alias PhoenixKit.Utils.Date, as: UtilsDate
 
   # Suppress dialyzer false positives for pattern matches
@@ -683,12 +684,28 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
   end
 
   defp maybe_add_initial_timestamp(post_attrs, "timestamp", now) do
-    date = DateTime.to_date(now)
-    time = %Time{hour: now.hour, minute: now.minute, second: 0, microsecond: {0, 0}}
+    # Stamp the post's date/time in the configured site time zone, NOT raw UTC.
+    # Timestamp-mode post_date/post_time are pure Date/Time values shown as-is
+    # (no display conversion), and an edit stores the editor's naive wall clock —
+    # so stamping creation in UTC made a freshly-created post disagree with an
+    # edited one about which day it lives under (L5). No-op when time_zone is "0".
+    local_now = shift_to_site_timezone(now)
+    date = DateTime.to_date(local_now)
+    time = %Time{hour: local_now.hour, minute: local_now.minute, second: 0, microsecond: {0, 0}}
     Map.merge(post_attrs, %{post_date: date, post_time: time})
   end
 
   defp maybe_add_initial_timestamp(post_attrs, _mode, _now), do: post_attrs
+
+  # Shift a UTC datetime by the configured site `time_zone` (integer-hour offset,
+  # default "0"). Mirrors the offset the display/edit layers use, so create/edit/
+  # display all agree on a timestamp post's wall clock. Bad/missing setting → UTC.
+  defp shift_to_site_timezone(datetime) do
+    case Integer.parse(Settings.get_setting("time_zone", "0")) do
+      {offset_hours, ""} -> DateTime.add(datetime, offset_hours * 3600, :second)
+      _ -> datetime
+    end
+  end
 
   defp resolve_timestamp_in_transaction(post_attrs, "timestamp", group_slug) do
     {date, time} =

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -933,9 +933,28 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
     end
   rescue
     e ->
-      Logger.warning("[Publishing] update_post_in_db failed: #{inspect(e)}")
-      {:error, :db_update_failed}
+      if db_exception?(e) do
+        Logger.warning("[Publishing] update_post_in_db DB error: #{inspect(e)}")
+        {:error, :db_update_failed}
+      else
+        # Don't swallow programmer errors as a generic DB failure — surface them
+        # (with a stacktrace) so real bugs aren't masked as "save failed" (L11).
+        Logger.error(
+          "[Publishing] update_post_in_db bug: " <> Exception.format(:error, e, __STACKTRACE__)
+        )
+
+        reraise(e, __STACKTRACE__)
+      end
   end
+
+  # True for the database-level exceptions an update can legitimately raise (so
+  # they degrade to {:error, :db_update_failed}); everything else is a code bug.
+  defp db_exception?(%Postgrex.Error{}), do: true
+  defp db_exception?(%DBConnection.ConnectionError{}), do: true
+  defp db_exception?(%Ecto.StaleEntryError{}), do: true
+  defp db_exception?(%Ecto.ConstraintError{}), do: true
+  defp db_exception?(%Ecto.Query.CastError{}), do: true
+  defp db_exception?(_), do: false
 
   # Find the DB post record for update, using UUID, date/time, or slug as available
   defp find_db_post_for_update(group_slug, post) do

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -1233,10 +1233,15 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
       |> maybe_put_version_field("seo", Map.get(params, "seo"))
       |> maybe_put_version_field("excerpt", Map.get(params, "excerpt"))
 
-    # Also update version-level status and published_at if provided
+    # Also update version-level status and published_at if provided.
+    # "published" is NEVER written here — it is set atomically with
+    # active_version_uuid by Versions.publish_version/4. Writing it here (a
+    # separate transaction) let a save commit status=published while the paired
+    # publish rolled back (e.g. empty primary title), leaving a post that reads
+    # "published" with no active version — admin shows published, public 404s (M4).
     version_attrs =
       %{data: new_data}
-      |> maybe_put(:status, Map.get(params, "status"))
+      |> maybe_put(:status, deferred_publish_status(Map.get(params, "status")))
       |> maybe_put(:published_at, parse_published_at_from_params(params))
 
     case DBStorage.update_version(version, version_attrs) do
@@ -1247,6 +1252,12 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
 
   defp maybe_put_version_field(data, _key, nil), do: data
   defp maybe_put_version_field(data, key, value), do: Map.put(data, key, value)
+
+  # Drop a "published" status so it is never written outside publish_version/4's
+  # atomic transaction (see update_version_defaults/4). draft/archived/nil pass
+  # through unchanged.
+  defp deferred_publish_status("published"), do: nil
+  defp deferred_publish_status(status), do: status
 
   defp parse_published_at_from_params(params) do
     case Map.get(params, "published_at") do

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -490,6 +490,12 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
       slug: post.slug,
       url_slug: content.url_slug,
       language: content.language,
+      # Routing fields, mirroring the cache shape (Mapper.to_listing_map/4) so a
+      # 301 redirect built from this map resolves to the right canonical URL for
+      # both slug- and timestamp-mode posts instead of guessing the mode.
+      mode: post.mode,
+      date: post.post_date,
+      time: post.post_time,
       metadata: %{
         title: content.title,
         status: version.status,

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -1040,7 +1040,10 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
       end
 
     # Content data only holds content-row-specific metadata (previous_url_slugs, etc.)
-    content_data = preserve_content_data(existing_data, params, post)
+    content_data =
+      existing_data
+      |> preserve_content_data(params, post)
+      |> record_previous_url_slug(existing_url_slug, resolved_url_slug)
 
     case DBStorage.upsert_content(%{
            version_uuid: version.uuid,
@@ -1072,6 +1075,29 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
   # legacy row and is logged via `ActivityLog.log/1`.
   defp preserve_content_data(existing_data, _params, _post) do
     Map.take(existing_data, @content_only_data_keys)
+  end
+
+  # When a content row's custom url_slug changes, record the OLD slug so the
+  # 301-redirect machinery (find_by_previous_url_slug/3) can forward its stale
+  # URLs to the new one. Without this writer the whole previous-slug system
+  # consumed data nothing produced — renaming a url_slug 404'd every old URL.
+  #
+  # The new slug is dropped from the history (so reverting A->B->A can't leave a
+  # previous-slug pointing at the current URL, which would 301-loop), and the
+  # list is deduped, newest-first.
+  defp record_previous_url_slug(data, old_slug, new_slug)
+       when old_slug in [nil, ""] or old_slug == new_slug,
+       do: data
+
+  defp record_previous_url_slug(data, old_slug, new_slug) do
+    previous = data["previous_url_slugs"] || []
+
+    updated =
+      [old_slug | previous]
+      |> Enum.reject(&(&1 in [nil, "", new_slug]))
+      |> Enum.uniq()
+
+    Map.put(data, "previous_url_slugs", updated)
   end
 
   # Reads the current content row and returns a map of legacy V1 keys that

--- a/lib/phoenix_kit_publishing/posts.ex
+++ b/lib/phoenix_kit_publishing/posts.ex
@@ -988,16 +988,53 @@ defmodule PhoenixKit.Modules.Publishing.Posts do
       # save; promotion runs once per legacy row and is logged via Activity.
       legacy_promotions = collect_legacy_content_promotions(version, language)
 
+      write_ctx = %{
+        language: language,
+        new_title: new_title,
+        content: content,
+        params: params,
+        post: post,
+        db_post: db_post,
+        audit_meta: audit_meta,
+        legacy_promotions: legacy_promotions
+      }
+
       with :ok <- validate_title_for_publish(language, new_status, new_title),
-           :ok <- upsert_post_content(version, language, new_title, content, params, post),
-           :ok <- update_version_defaults(version, params, post, legacy_promotions),
-           {:ok, db_post} <- maybe_sync_datetime_and_audit(db_post, params, audit_meta) do
+           {:ok, db_post} <- persist_post_update(version, write_ctx) do
         log_legacy_metadata_promoted(legacy_promotions, version, language)
         read_updated_post(db_post, group_slug, final_slug, language, version_number)
       end
     else
       {:error, :not_found}
     end
+  end
+
+  # Persist the three coupled writes of a post update in ONE transaction.
+  # `upsert_post_content/6` strips the legacy V1 keys (description,
+  # featured_image_uuid, seo_title, excerpt) from the content row that
+  # `update_version_defaults/4` then re-persists at the version level. Without the
+  # transaction, a failure in between committed the wipe but not the promotion —
+  # destroying those values permanently (M3).
+  defp persist_post_update(version, ctx) do
+    repo = PhoenixKit.RepoHelper.repo()
+
+    repo.transaction(fn ->
+      with :ok <-
+             upsert_post_content(
+               version,
+               ctx.language,
+               ctx.new_title,
+               ctx.content,
+               ctx.params,
+               ctx.post
+             ),
+           :ok <- update_version_defaults(version, ctx.params, ctx.post, ctx.legacy_promotions),
+           {:ok, synced} <- maybe_sync_datetime_and_audit(ctx.db_post, ctx.params, ctx.audit_meta) do
+        synced
+      else
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
   end
 
   @default_title Constants.default_title()

--- a/lib/phoenix_kit_publishing/presence_helpers.ex
+++ b/lib/phoenix_kit_publishing/presence_helpers.ex
@@ -134,7 +134,14 @@ defmodule PhoenixKit.Modules.Publishing.PresenceHelpers do
     |> Enum.sort_by(fn {_socket_id, meta} -> meta.joined_at end)
   end
 
-  defp meta_alive?(%{pid: pid}) when is_pid(pid), do: Process.alive?(pid)
+  # Process.alive?/1 raises ArgumentError on a REMOTE pid, and clustered presence
+  # metas can carry pids from other nodes — so only check locally. A remote pid is
+  # assumed alive (Presence's own node-down tracking cleans up dead nodes); this
+  # avoids crashing the presence-diff handler on a 2+ node cluster (M14).
+  defp meta_alive?(%{pid: pid}) when is_pid(pid) do
+    node(pid) != node() or Process.alive?(pid)
+  end
+
   defp meta_alive?(_), do: true
 
   @doc """

--- a/lib/phoenix_kit_publishing/publishing.ex
+++ b/lib/phoenix_kit_publishing/publishing.ex
@@ -185,7 +185,10 @@ defmodule PhoenixKit.Modules.Publishing do
   defdelegate delete_language(group_slug, post_uuid, language_code, version \\ nil),
     to: TranslationManager
 
-  defdelegate clear_translation(group_slug, post_uuid, language_code, opts \\ []),
+  defdelegate clear_translation(group_slug, post_uuid, language_code, version, opts),
+    to: TranslationManager
+
+  defdelegate clear_translation(group_slug, post_uuid, language_code, version \\ nil),
     to: TranslationManager
 
   defdelegate set_translation_status(group_slug, post_identifier, version, language, status),

--- a/lib/phoenix_kit_publishing/publishing.ex
+++ b/lib/phoenix_kit_publishing/publishing.ex
@@ -384,6 +384,9 @@ defmodule PhoenixKit.Modules.Publishing do
   def children do
     [
       PhoenixKit.Modules.Publishing.Presence,
+      # Owns the ListingCache regeneration-lock ETS table so it outlives the
+      # transient request processes that would otherwise create (and destroy) it.
+      PhoenixKit.Modules.Publishing.ListingCache.LockTableOwner,
       # Per-post render cache (Renderer.render_post_cached/1). Without this the
       # cache GenServer never starts, so every published view re-renders markdown
       # and logs a per-request warning. max_size bounds growth — the cache key

--- a/lib/phoenix_kit_publishing/publishing.ex
+++ b/lib/phoenix_kit_publishing/publishing.ex
@@ -381,7 +381,19 @@ defmodule PhoenixKit.Modules.Publishing do
   end
 
   @impl PhoenixKit.Module
-  def children, do: [PhoenixKit.Modules.Publishing.Presence]
+  def children do
+    [
+      PhoenixKit.Modules.Publishing.Presence,
+      # Per-post render cache (Renderer.render_post_cached/1). Without this the
+      # cache GenServer never starts, so every published view re-renders markdown
+      # and logs a per-request warning. max_size bounds growth — the cache key
+      # folds in a content hash, so each edit mints a new key (FIFO-evicted).
+      Supervisor.child_spec(
+        {PhoenixKit.Cache, name: :publishing_posts, ttl: :timer.hours(24), max_size: 2000},
+        id: :publishing_posts_cache
+      )
+    ]
+  end
 
   @impl PhoenixKit.Module
   def route_module, do: PhoenixKitPublishing.Routes

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -42,8 +42,8 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   @global_cache_key "publishing_render_cache_enabled"
   @per_group_cache_prefix "publishing_render_cache_enabled_"
 
-  @component_regex ~r/<(Image|Hero|CTA|Headline|Subheadline|Video|EntityForm)\s+([^>]*?)\/>/s
-  @component_block_regex ~r/<(Hero|CTA|Headline|Subheadline|Video|EntityForm)\s*([^>]*)>(.*?)<\/\1>/s
+  @component_regex ~r/<(Image|CTA|Headline|Subheadline|Video|EntityForm)\s+([^>]*?)\/>/s
+  @component_block_regex ~r/<(CTA|Headline|Subheadline|Video|EntityForm)\s*([^>]*)>(.*?)<\/\1>/s
 
   # Fenced (```…``` or ~~~…~~~) and inline (`…`) code spans — masked out before
   # the component scan so a literal component example inside a code block isn't
@@ -171,19 +171,14 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   def render_markdown(content) when is_binary(content) do
     {time, result} =
       :timer.tc(fn ->
-        cond do
-          pure_phk_content?(content) ->
-            render_phk_content(content)
-
-          has_embedded_components?(content) ->
-            render_mixed_content(content)
-
-          true ->
-            # Escape code regions on the plain path too, so raw HTML inside a
-            # ```fence``` (e.g. <script>) renders as literal text instead of
-            # executing — matching the mixed path. escape: false makes this the
-            # only thing standing between a fenced <script> and live HTML.
-            render_earmark_markdown(escape_code_regions(content))
+        if has_embedded_components?(content) do
+          render_mixed_content(content)
+        else
+          # Escape code regions on the plain path too, so raw HTML inside a
+          # ```fence``` (e.g. <script>) renders as literal text instead of
+          # executing — matching the mixed path. escape: false makes this the
+          # only thing standing between a fenced <script> and live HTML.
+          render_earmark_markdown(escape_code_regions(content))
         end
       end)
 
@@ -211,39 +206,17 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
 
   defp heal_signed_file_urls(other), do: other
 
-  # Detect if content is pure PHK XML format (starts with <Page> or <Hero>)
-  defp pure_phk_content?(content) do
-    trimmed = String.trim(content)
-    String.starts_with?(trimmed, "<Page") || String.starts_with?(trimmed, "<Hero")
-  end
-
   # Detect if markdown content has embedded XML components
   defp has_embedded_components?(content) do
     # `<Image` may be followed by a space OR a newline (the format spec's own
     # examples put the attributes on the next line); match either so multi-line
     # tags route through the component path instead of being smartypants-mangled.
     Regex.match?(~r/<Image[\s>]/, content) ||
-      String.contains?(content, "<Hero") ||
       String.contains?(content, "<CTA") ||
       String.contains?(content, "<Headline") ||
       String.contains?(content, "<Subheadline") ||
       String.contains?(content, "<Video") ||
       String.contains?(content, "<EntityForm")
-  end
-
-  # Render PHK content using PageBuilder
-  defp render_phk_content(content) do
-    case PageBuilder.render_content(content) do
-      {:ok, html} ->
-        # Convert Phoenix.LiveView.Rendered to string
-        html
-        |> Safe.to_iodata()
-        |> IO.iodata_to_binary()
-
-      {:error, reason} ->
-        Logger.warning("PHK render error: #{inspect(reason)}")
-        "<p>Error rendering page content</p>"
-    end
   end
 
   # Render markdown using Earmark, then inject Tailwind/daisyUI classes on each tag.
@@ -390,7 +363,7 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
 
   defp render_mixed_content(content) do
     # Escape HTML inside fenced/inline code spans BEFORE scanning for components,
-    # so a `<Image>`/`<Hero>`/… shown literally inside a code block (a docs post
+    # so a `<Image>`/`<CTA>`/… shown literally inside a code block (a docs post
     # demonstrating the PHK syntax) (a) no longer matches the component regex
     # (it's now `&lt;Image`) and (b) renders as visible code text — `escape:
     # false` would otherwise leave the raw tag in `<code>`, where the browser

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -179,7 +179,11 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
             render_mixed_content(content)
 
           true ->
-            render_earmark_markdown(content)
+            # Escape code regions on the plain path too, so raw HTML inside a
+            # ```fence``` (e.g. <script>) renders as literal text instead of
+            # executing — matching the mixed path. escape: false makes this the
+            # only thing standing between a fenced <script> and live HTML.
+            render_earmark_markdown(escape_code_regions(content))
         end
       end)
 
@@ -215,7 +219,10 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
 
   # Detect if markdown content has embedded XML components
   defp has_embedded_components?(content) do
-    String.contains?(content, "<Image ") ||
+    # `<Image` may be followed by a space OR a newline (the format spec's own
+    # examples put the attributes on the next line); match either so multi-line
+    # tags route through the component path instead of being smartypants-mangled.
+    Regex.match?(~r/<Image[\s>]/, content) ||
       String.contains?(content, "<Hero") ||
       String.contains?(content, "<CTA") ||
       String.contains?(content, "<Headline") ||
@@ -272,7 +279,23 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   end
 
   defp normalize_markdown(content) when is_binary(content) do
-    content
+    # Apply the prose normalizers ONLY outside code regions. Run over the whole
+    # document they corrupt code samples: the heading-indent strip deletes the
+    # indentation from `  ## comment` lines inside a fence, and the blank-line
+    # spacer injects literal &nbsp; into runs of blank lines in code. Split on
+    # code regions (delimiters included) — even segments are prose, odd are code
+    # left verbatim — then rejoin.
+    @code_region_regex
+    |> Regex.split(content, include_captures: true)
+    |> Enum.with_index()
+    |> Enum.map_join("", fn
+      {segment, index} when rem(index, 2) == 0 -> normalize_prose(segment)
+      {code_region, _index} -> code_region
+    end)
+  end
+
+  defp normalize_prose(segment) do
+    segment
     # Remove leading indentation before Markdown headings (e.g., "  ## Title")
     |> then(&Regex.replace(~r/^[ \t]+(?=#)/m, &1, ""))
     # Preserve intentional blank lines: convert runs of 2+ blank lines into

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -45,12 +45,14 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   @component_regex ~r/<(Image|CTA|Headline|Subheadline|Video|EntityForm)\s+([^>]*?)\/>/s
   @component_block_regex ~r/<(CTA|Headline|Subheadline|Video|EntityForm)\s*([^>]*)>(.*?)<\/\1>/s
 
-  # Fenced (```…``` or ~~~…~~~) and inline (`…`) code spans — masked out before
-  # the component scan so a literal component example inside a code block isn't
-  # rendered as a real component. Fenced first so it wins at a fence boundary.
+  # Fenced (```…``` or ~~~…~~~), double-backtick inline (``…``) and single
+  # inline (`…`) code spans — masked out before the component scan so a literal
+  # component example inside a code block isn't rendered as a real component.
+  # Order matters: fences first (win at a fence boundary), then double-backtick
+  # (so ``a`b`` isn't split by the single-backtick branch), then single.
   # Known limitation: 4+ backtick fences and backslash-escaped backticks (rare
   # CommonMark corners) aren't matched and would still be scanned for components.
-  @code_region_regex ~r/```.*?```|~~~.*?~~~|`[^`\n]*`/s
+  @code_region_regex ~r/```.*?```|~~~.*?~~~|``[^\n]+?``|`[^`\n]*`/s
 
   # Tailwind/daisyUI classes for post-processing Earmark HTML output.
   # Code blocks (pre, code) are handled separately in style_code_blocks/1.

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -42,10 +42,12 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   @component_regex ~r/<(Image|Hero|CTA|Headline|Subheadline|Video|EntityForm)\s+([^>]*?)\/>/s
   @component_block_regex ~r/<(Hero|CTA|Headline|Subheadline|Video|EntityForm)\s*([^>]*)>(.*?)<\/\1>/s
 
-  # Fenced (```…```) and inline (`…`) code spans — masked out before the
-  # component scan so a literal component example inside a code block isn't
-  # rendered as a real component. Fenced first so it wins at a ``` boundary.
-  @code_region_regex ~r/```.*?```|`[^`\n]*`/s
+  # Fenced (```…``` or ~~~…~~~) and inline (`…`) code spans — masked out before
+  # the component scan so a literal component example inside a code block isn't
+  # rendered as a real component. Fenced first so it wins at a fence boundary.
+  # Known limitation: 4+ backtick fences and backslash-escaped backticks (rare
+  # CommonMark corners) aren't matched and would still be scanned for components.
+  @code_region_regex ~r/```.*?```|~~~.*?~~~|`[^`\n]*`/s
 
   # Tailwind/daisyUI classes for post-processing Earmark HTML output.
   # Code blocks (pre, code) are handled separately in style_code_blocks/1.

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -21,10 +21,13 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   @compile {:no_warn_undefined, @entity_form_mod}
 
   @cache_name :publishing_posts
-  # v3: render output now heals legacy signed-file URLs against the current
-  # url_prefix/secret (see heal_signed_file_urls/1) — bump drops stale v2
-  # entries that still carry an old prefix baked into <img src>.
-  @cache_version "v3"
+  # Bump whenever render OUTPUT changes for unchanged source content, so already
+  # cached HTML is dropped instead of served stale.
+  # v3: heal legacy signed-file URLs against the current url_prefix/secret.
+  # v4: escape PHK component tags inside code regions (```/~~~/inline) so they
+  #     render as literal text — without the bump, posts cached under v3 keep
+  #     rendering the component live from inside the code block.
+  @cache_version "v4"
 
   # Matches the internal signed-file route — `<prefix>/file/<uuid>/<variant>/<token>`
   # — embedded as an `<img src>`. The prefix is bounded to plain path segments

--- a/lib/phoenix_kit_publishing/renderer.ex
+++ b/lib/phoenix_kit_publishing/renderer.ex
@@ -42,6 +42,11 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   @component_regex ~r/<(Image|Hero|CTA|Headline|Subheadline|Video|EntityForm)\s+([^>]*?)\/>/s
   @component_block_regex ~r/<(Hero|CTA|Headline|Subheadline|Video|EntityForm)\s*([^>]*)>(.*?)<\/\1>/s
 
+  # Fenced (```…```) and inline (`…`) code spans — masked out before the
+  # component scan so a literal component example inside a code block isn't
+  # rendered as a real component. Fenced first so it wins at a ``` boundary.
+  @code_region_regex ~r/```.*?```|`[^`\n]*`/s
+
   # Tailwind/daisyUI classes for post-processing Earmark HTML output.
   # Code blocks (pre, code) are handled separately in style_code_blocks/1.
   @pre_classes "bg-base-300 p-4 rounded-lg overflow-x-auto my-4"
@@ -356,10 +361,28 @@ defmodule PhoenixKit.Modules.Publishing.Renderer do
   defp render_mixed_content(content) when content == "" or is_nil(content), do: ""
 
   defp render_mixed_content(content) do
+    # Escape HTML inside fenced/inline code spans BEFORE scanning for components,
+    # so a `<Image>`/`<Hero>`/… shown literally inside a code block (a docs post
+    # demonstrating the PHK syntax) (a) no longer matches the component regex
+    # (it's now `&lt;Image`) and (b) renders as visible code text — `escape:
+    # false` would otherwise leave the raw tag in `<code>`, where the browser
+    # swallows it. Components OUTSIDE code blocks are untouched and still render.
     content
+    |> escape_code_regions()
     |> render_mixed_segments([])
     |> Enum.reverse()
     |> Enum.join()
+  end
+
+  # Escape <, >, & inside ```fenced``` and `inline` code spans, leaving the
+  # fence/backtick delimiters intact so the markdown still parses as code.
+  defp escape_code_regions(content) do
+    Regex.replace(@code_region_regex, content, fn match ->
+      match
+      |> String.replace("&", "&amp;")
+      |> String.replace("<", "&lt;")
+      |> String.replace(">", "&gt;")
+    end)
   end
 
   defp render_mixed_segments("", acc), do: acc

--- a/lib/phoenix_kit_publishing/router_dispatch.ex
+++ b/lib/phoenix_kit_publishing/router_dispatch.ex
@@ -47,6 +47,7 @@ defmodule PhoenixKitPublishing.RouterDispatch do
   """
 
   alias PhoenixKit.Modules.Publishing.Groups
+  alias PhoenixKit.Modules.Publishing.Web.Controller.Language
 
   @internal_prefix "__phoenix_kit_publishing_dispatch"
   @localized_segment "localized"
@@ -111,6 +112,13 @@ defmodule PhoenixKitPublishing.RouterDispatch do
   routes (also nested under the prefix).
   """
   @spec maybe_rewrite(Plug.Conn.t(), String.t()) :: {:rewrite, Plug.Conn.t()} | :pass
+  # Public publishing routes are read-only — only GET/HEAD are rewritten. Without
+  # this a host's `POST /blog/...` (blog being a group) would be diverted into the
+  # GET-only internal scope and 404, shadowing the host's own form/webhook route.
+  def maybe_rewrite(%Plug.Conn{method: method}, url_prefix)
+      when is_binary(url_prefix) and method not in ["GET", "HEAD"],
+      do: :pass
+
   def maybe_rewrite(%Plug.Conn{path_info: path_info} = conn, url_prefix)
       when is_binary(url_prefix) do
     prefix_segments = split_prefix(url_prefix)
@@ -118,10 +126,13 @@ defmodule PhoenixKitPublishing.RouterDispatch do
     case strip_prefix(path_info, prefix_segments) do
       {:ok, rest} ->
         cond do
-          candidate_at(rest, 1) |> known_group?() ->
+          # Localized shape `/:language/:group` — segment 0 MUST be a language the
+          # site actually serves, else any host URL `/<seg>/<group-named-seg>` (e.g.
+          # `/company/news`, `/api/news`) would be hijacked into publishing.
+          localized_locale?(candidate_at(rest, 0)) and known_group?(candidate_at(rest, 1)) ->
             {:rewrite, rewrite(conn, @localized_segment, prefix_segments, rest)}
 
-          candidate_at(rest, 0) |> known_group?() ->
+          known_group?(candidate_at(rest, 0)) ->
             {:rewrite, rewrite(conn, @root_segment, prefix_segments, rest)}
 
           true ->
@@ -131,6 +142,22 @@ defmodule PhoenixKitPublishing.RouterDispatch do
       :mismatch ->
         :pass
     end
+  end
+
+  # A URL locale segment is valid only if it's an enabled language, or a base code
+  # (e.g. "en") that resolves to an enabled dialect (e.g. "en-US"). This is stricter
+  # than `looks_like_language_code?/1` on purpose — the latter accepts any 2–3 letter
+  # token ("api", "faq"), which is the gap that let host routes get hijacked.
+  @spec localized_locale?(String.t() | nil) :: boolean()
+  defp localized_locale?(nil), do: false
+
+  defp localized_locale?(seg) when is_binary(seg) do
+    enabled = Language.get_enabled_languages()
+
+    seg in enabled or
+      (Language.base_code?(seg) and Language.find_dialect_for_base(seg, enabled) != nil)
+  rescue
+    _ -> false
   end
 
   @doc """

--- a/lib/phoenix_kit_publishing/schemas/publishing_version.ex
+++ b/lib/phoenix_kit_publishing/schemas/publishing_version.ex
@@ -17,7 +17,6 @@ defmodule PhoenixKit.Modules.Publishing.PublishingVersion do
   ### Version metadata (defaults for all languages)
   - `featured_image_uuid` - Featured image reference (media UUID)
   - `tags` - List of tag strings
-  - `seo` - SEO metadata map (og_title, og_description, og_image, etc.)
   - `description` - SEO meta description
   - `allow_version_access` - Whether older versions are publicly accessible
 
@@ -99,9 +98,6 @@ defmodule PhoenixKit.Modules.Publishing.PublishingVersion do
 
   @doc "Returns the post tags."
   def get_tags(%__MODULE__{data: data}), do: Map.get(data, "tags", [])
-
-  @doc "Returns SEO metadata."
-  def get_seo(%__MODULE__{data: data}), do: Map.get(data, "seo", %{})
 
   @doc "Returns the SEO description."
   def get_description(%__MODULE__{data: data}), do: Map.get(data, "description")

--- a/lib/phoenix_kit_publishing/slug_helpers.ex
+++ b/lib/phoenix_kit_publishing/slug_helpers.ex
@@ -275,9 +275,30 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
       url_slug_exists?(group_slug, url_slug, language, exclude_post_slug) ->
         {:error, :slug_already_exists}
 
+      claims_other_posts_previous_slug?(group_slug, url_slug, language, exclude_post_slug) ->
+        {:error, :conflicts_with_previous_slug}
+
       true ->
         {:ok, url_slug}
     end
+  end
+
+  # Reject claiming a slug that is another post's PREVIOUS slug — taking it would
+  # hijack that post's 301 redirect (current-slug lookup wins over previous-slug),
+  # silently stealing its old-URL traffic. Advisory: fail OPEN on a DB hiccup so a
+  # transient error doesn't block saves (unlike url_slug_exists?/4, the hard
+  # uniqueness gate, which fails closed).
+  defp claims_other_posts_previous_slug?(group_slug, url_slug, language, exclude_post_slug) do
+    DBStorage.previous_url_slug_taken_by_other_post?(
+      group_slug,
+      language,
+      url_slug,
+      exclude_post_slug
+    )
+  rescue
+    error ->
+      Logger.warning("[Slugs] previous-slug containment check failed: #{inspect(error)}")
+      false
   end
 
   @doc """

--- a/lib/phoenix_kit_publishing/slug_helpers.ex
+++ b/lib/phoenix_kit_publishing/slug_helpers.ex
@@ -298,16 +298,22 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
   """
   @spec clear_conflicting_url_slugs(String.t(), String.t()) :: [{String.t(), String.t()}]
   def clear_conflicting_url_slugs(group_slug, post_slug) do
-    case ListingCache.read(group_slug) do
-      {:ok, posts} ->
-        conflicts = find_conflicting_url_slugs(posts, post_slug)
-        clear_url_slugs_for_conflicts(group_slug, post_slug, conflicts)
-        log_cleared_conflicts(conflicts, post_slug)
-        conflicts
+    # On a cache miss, fall back to the SAME source the cache is built from
+    # (`list_posts_for_listing/1`), so the conflict scan sees identical
+    # `:language_slugs`-bearing maps either way. This is a mutation path:
+    # silently returning [] on a miss (memory cache disabled, or a loser of a
+    # concurrent regeneration) would skip conflict cleanup and leave a stale
+    # custom url_slug pointing at the wrong post.
+    posts =
+      case ListingCache.read(group_slug) do
+        {:ok, posts} -> posts
+        {:error, _} -> DBStorage.list_posts_for_listing(group_slug)
+      end
 
-      {:error, _} ->
-        []
-    end
+    conflicts = find_conflicting_url_slugs(posts, post_slug)
+    clear_url_slugs_for_conflicts(group_slug, post_slug, conflicts)
+    log_cleared_conflicts(conflicts, post_slug)
+    conflicts
   end
 
   @doc """

--- a/lib/phoenix_kit_publishing/slug_helpers.ex
+++ b/lib/phoenix_kit_publishing/slug_helpers.ex
@@ -237,6 +237,12 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
       LanguageHelpers.reserved_language_code?(slug) ->
         {:error, :reserved_language_code}
 
+      # Post/group slugs become URL segments too, so reject route words like
+      # "admin"/"api" the same way url_slugs do — a post slugged "admin" is
+      # unreachable behind the host's own routes.
+      slug in @reserved_route_words ->
+        {:error, :reserved_route_word}
+
       true ->
         {:ok, slug}
     end

--- a/lib/phoenix_kit_publishing/slug_helpers.ex
+++ b/lib/phoenix_kit_publishing/slug_helpers.ex
@@ -385,7 +385,17 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpers do
     # arbitrarily-ordered match is the post being edited.
     DBStorage.url_slug_taken_by_other_post?(group_slug, language, url_slug, exclude_post_slug)
   rescue
-    _ -> false
+    error ->
+      # Fail CLOSED on a uniqueness gate: a DB hiccup must reject the save, not
+      # silently approve a possibly-duplicate url_slug (there's no DB unique index
+      # backing this, so this check is the only guard). Logged so a persistent
+      # failure is diagnosable rather than silently blocking every save.
+      Logger.warning(
+        "[Slugs] url_slug uniqueness check failed for #{inspect(url_slug)}, " <>
+          "treating as taken: #{inspect(error)}"
+      )
+
+      true
   end
 
   defp slug_exists_for_generation?(_group_slug, candidate, current_slug)

--- a/lib/phoenix_kit_publishing/stale_fixer.ex
+++ b/lib/phoenix_kit_publishing/stale_fixer.ex
@@ -115,8 +115,7 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
     # restore → auto-trash loop. Skip recently created posts to avoid killing
     # posts before the editor has had a chance to autosave.
     if empty_post?(ctx) and past_grace_period?(post) do
-      Logger.info("[Publishing] Deleting empty post #{post.uuid} (no content in any version)")
-      DBStorage.delete_post(post)
+      delete_empty_post(post)
       post
     else
       post = apply_stale_fix(post, build_post_fixes(post, ctx), &DBStorage.update_post/2)
@@ -132,6 +131,19 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
 
       DBStorage.get_post_by_uuid(post.uuid, [:group]) || post
     end
+  end
+
+  # `fix_stale_post/1` runs on the read path, so two concurrent requests can both
+  # decide to delete the same empty post — the loser hits Ecto.StaleEntryError.
+  # A read must never 500 over that benign race; the post is gone either way.
+  defp delete_empty_post(post) do
+    Logger.info("[Publishing] Deleting empty post #{post.uuid} (no content in any version)")
+    DBStorage.delete_post(post)
+  rescue
+    Ecto.StaleEntryError ->
+      Logger.debug("[Publishing] Empty post #{post.uuid} already removed by a concurrent request")
+
+      :ok
   end
 
   defp empty_post?(ctx) do

--- a/lib/phoenix_kit_publishing/stale_fixer.ex
+++ b/lib/phoenix_kit_publishing/stale_fixer.ex
@@ -121,6 +121,7 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
       post = apply_stale_fix(post, build_post_fixes(post, ctx), &DBStorage.update_post/2)
 
       # Fix version/content-level issues
+      demote_orphaned_published_versions(post, ctx)
       fix_multiple_published_versions(post, ctx)
 
       for version <- ctx.versions do
@@ -711,6 +712,27 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
     ctx = build_post_context(post)
     fix_multiple_published_versions(post, ctx)
   end
+
+  # M4 heal: a save can no longer mark a version "published" without
+  # publish_version atomically activating it, but a legacy or interrupted publish
+  # can leave a version with status "published" while the post has NO active
+  # version — the admin list shows it published while the public page 404s.
+  # Demote those orphans back to draft so the two views agree.
+  defp demote_orphaned_published_versions(%{active_version_uuid: nil} = post, ctx) do
+    orphans = Enum.filter(ctx.versions, &(&1.status == "published"))
+
+    for v <- orphans do
+      Logger.info(
+        "[Publishing] Demoting orphaned published v#{v.version_number} of post " <>
+          "#{post.uuid} to draft (post has no active version)"
+      )
+
+      DBStorage.update_version(v, %{status: "draft"})
+      DBStorage.update_content_status(v.uuid, "draft")
+    end
+  end
+
+  defp demote_orphaned_published_versions(_post, _ctx), do: :ok
 
   defp fix_multiple_published_versions(post, ctx) do
     published = Enum.filter(ctx.versions, &(&1.status == "published"))

--- a/lib/phoenix_kit_publishing/stale_fixer.ex
+++ b/lib/phoenix_kit_publishing/stale_fixer.ex
@@ -110,12 +110,12 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
   end
 
   defp do_fix_stale_post(post, ctx) do
-    # Hard-delete empty posts (no content in any version) — they're abandoned
-    # drafts with no recoverable content, so trashing them just creates a
-    # restore → auto-trash loop. Skip recently created posts to avoid killing
-    # posts before the editor has had a chance to autosave.
-    if empty_post?(ctx) and past_grace_period?(post) do
-      delete_empty_post(post)
+    # Trash (soft-delete) empty posts (no content + no featured image in any
+    # version) — abandoned drafts. Skip recently created posts so the editor has
+    # time to autosave, and skip already-trashed posts so a restore isn't fought
+    # in a tight loop. Trash (not hard-delete) keeps it recoverable and logged.
+    if empty_post?(ctx) and past_grace_period?(post) and is_nil(post.trashed_at) do
+      trash_empty_post(post)
       post
     else
       post = apply_stale_fix(post, build_post_fixes(post, ctx), &DBStorage.update_post/2)
@@ -135,11 +135,24 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
   end
 
   # `fix_stale_post/1` runs on the read path, so two concurrent requests can both
-  # decide to delete the same empty post — the loser hits Ecto.StaleEntryError.
-  # A read must never 500 over that benign race; the post is gone either way.
-  defp delete_empty_post(post) do
-    Logger.info("[Publishing] Deleting empty post #{post.uuid} (no content in any version)")
-    DBStorage.delete_post(post)
+  # decide to trash the same empty post — the loser hits Ecto.StaleEntryError.
+  # A read must never 500 over that benign race; the post is trashed either way.
+  defp trash_empty_post(post) do
+    Logger.info("[Publishing] Trashing empty post #{post.uuid} (no content in any version)")
+
+    case DBStorage.update_post(post, %{trashed_at: DateTime.utc_now()}) do
+      {:ok, _} ->
+        ActivityLog.log_manual(
+          "publishing.post.auto_trashed",
+          nil,
+          "publishing_post",
+          post.uuid,
+          %{"reason" => "empty_post", "group_uuid" => post.group_uuid}
+        )
+
+      {:error, _reason} ->
+        :ok
+    end
   rescue
     Ecto.StaleEntryError ->
       Logger.debug("[Publishing] Empty post #{post.uuid} already removed by a concurrent request")
@@ -152,6 +165,19 @@ defmodule PhoenixKit.Modules.Publishing.StaleFixer do
   end
 
   defp version_empty?(ctx, version) do
+    not version_has_featured_image?(version) and version_contents_empty?(ctx, version)
+  end
+
+  # A featured-image-only version (no title/body) still holds user content — it
+  # must NOT count as empty, or the auto-trash would discard the image.
+  defp version_has_featured_image?(version) do
+    case (version.data || %{})["featured_image_uuid"] do
+      uuid when is_binary(uuid) and uuid != "" -> true
+      _ -> false
+    end
+  end
+
+  defp version_contents_empty?(ctx, version) do
     contents = Map.get(ctx.contents_by_version, version.uuid, [])
     contents == [] or Enum.all?(contents, &content_empty?/1)
   end

--- a/lib/phoenix_kit_publishing/translation_manager.ex
+++ b/lib/phoenix_kit_publishing/translation_manager.ex
@@ -227,11 +227,16 @@ defmodule PhoenixKit.Modules.Publishing.TranslationManager do
   Unlike `delete_language` (which archives), this permanently removes the content.
   Refuses to delete the last remaining language.
   """
-  @spec clear_translation(String.t(), String.t(), String.t(), keyword() | map()) ::
-          :ok | {:error, term()}
-  def clear_translation(group_slug, post_uuid, language_code, opts \\ []) do
+  @spec clear_translation(
+          String.t(),
+          String.t(),
+          String.t(),
+          pos_integer() | nil,
+          keyword() | map()
+        ) :: :ok | {:error, term()}
+  def clear_translation(group_slug, post_uuid, language_code, version \\ nil, opts \\ []) do
     with db_post when not is_nil(db_post) <- DBStorage.get_post_by_uuid(post_uuid, [:group]),
-         db_version when not is_nil(db_version) <- Shared.resolve_db_version(db_post, nil),
+         db_version when not is_nil(db_version) <- Shared.resolve_db_version(db_post, version),
          content when not is_nil(content) <-
            DBStorage.get_content(db_version.uuid, language_code),
          :ok <- validate_not_last_content(db_version, language_code),

--- a/lib/phoenix_kit_publishing/versions.ex
+++ b/lib/phoenix_kit_publishing/versions.ex
@@ -356,6 +356,36 @@ defmodule PhoenixKit.Modules.Publishing.Versions do
     PublishingPubSub.broadcast_post_version_published(group_slug, post_uuid, version, source_id)
   end
 
+  # Create an empty version + its site-default-language content row in ONE
+  # transaction, so a content-insert failure rolls the version back instead of
+  # orphaning an empty version (L4).
+  defp create_blank_version(db_post, created_by_uuid) do
+    primary_language = LanguageHelpers.get_primary_language()
+    repo = PhoenixKit.RepoHelper.repo()
+
+    repo.transaction(fn ->
+      with {:ok, db_version} <-
+             DBStorage.create_version(%{
+               post_uuid: db_post.uuid,
+               version_number: DBStorage.next_version_number(db_post.uuid),
+               status: "draft",
+               created_by_uuid: created_by_uuid
+             }),
+           {:ok, _content} <-
+             DBStorage.create_content(%{
+               version_uuid: db_version.uuid,
+               language: primary_language,
+               title: "",
+               content: "",
+               status: "draft"
+             }) do
+        db_version
+      else
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
+  end
+
   defp do_unpublish_post(group_slug, db_post, opts) do
     repo = PhoenixKit.RepoHelper.repo()
     target_status = Keyword.get(opts, :target_status, "draft")
@@ -364,7 +394,10 @@ defmodule PhoenixKit.Modules.Publishing.Versions do
       repo.transaction(fn ->
         lock_post!(repo, db_post.uuid)
 
-        # Find the currently active version
+        # Re-read under the lock so active_version_uuid reflects any publish that
+        # committed between the initial read and acquiring the row lock — otherwise
+        # we'd demote the wrong (stale) version (L3).
+        db_post = DBStorage.get_post_by_uuid(db_post.uuid) || db_post
         active_version = DBStorage.get_active_version(db_post)
 
         # Clear active_version_uuid on the post
@@ -571,26 +604,7 @@ defmodule PhoenixKit.Modules.Publishing.Versions do
       if source_version do
         DBStorage.create_version_from(db_post.uuid, source_version, user_opts)
       else
-        # Blank version — create empty version with site default language content
-        primary_language = LanguageHelpers.get_primary_language()
-
-        with {:ok, db_version} <-
-               DBStorage.create_version(%{
-                 post_uuid: db_post.uuid,
-                 version_number: DBStorage.next_version_number(db_post.uuid),
-                 status: "draft",
-                 created_by_uuid: created_by_uuid
-               }),
-             {:ok, _content} <-
-               DBStorage.create_content(%{
-                 version_uuid: db_version.uuid,
-                 language: primary_language,
-                 title: "",
-                 content: "",
-                 status: "draft"
-               }) do
-          {:ok, db_version}
-        end
+        create_blank_version(db_post, created_by_uuid)
       end
 
     with {:ok, db_version} <- result,

--- a/lib/phoenix_kit_publishing/web/controller.ex
+++ b/lib/phoenix_kit_publishing/web/controller.ex
@@ -364,15 +364,14 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
   end
 
   defp build_og_data(conn, post, canonical_url, language) do
-    seo = Map.get(post.metadata, :seo) || Map.get(post, :seo) || %{}
-    description = seo["og_description"] || Map.get(post.metadata, :description)
-    image = seo["og_image"] || PublishingHTML.featured_image_url(post, "large")
+    description = Map.get(post.metadata, :description)
+    image = PublishingHTML.featured_image_url(post, "large")
 
     base_url =
       "#{conn.scheme}://#{conn.host}#{if conn.port in [80, 443], do: "", else: ":#{conn.port}"}"
 
     %{
-      title: seo["og_title"] || post.metadata.title,
+      title: post.metadata.title,
       description: description,
       image: absolute_url(base_url, image),
       url: absolute_url(base_url, canonical_url),
@@ -390,8 +389,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
       # Protocol-relative (`//cdn/...`) is already absolute — leave it.
       String.starts_with?(url, "//") -> url
       String.starts_with?(url, "/") -> base <> url
-      # Bare relative (e.g. an admin-entered SEO `og_image` of "images/og.png")
-      # — treat as site-absolute so we don't emit "https://hostimages/og.png".
+      # Bare relative (e.g. a featured-image path like "images/og.png") — treat as
+      # site-absolute so we don't emit "https://hostimages/og.png".
       true -> base <> "/" <> url
     end
   end

--- a/lib/phoenix_kit_publishing/web/controller.ex
+++ b/lib/phoenix_kit_publishing/web/controller.ex
@@ -222,9 +222,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> render(:index)
 
       {:redirect_301, url} ->
-        conn
-        |> put_status(301)
-        |> redirect(to: url)
+        redirect_301(conn, url)
 
       {:error, reason} ->
         handle_not_found(conn, reason)
@@ -259,9 +257,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> render(:show)
 
       {:redirect_301, url} ->
-        conn
-        |> put_status(301)
-        |> redirect(to: url)
+        redirect_301(conn, url)
 
       {:error, reason} ->
         handle_not_found(conn, reason)
@@ -320,12 +316,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> render(:show)
 
       {:redirect, url} ->
-        redirect(conn, to: url)
+        redirect(conn, to: with_query_string(conn, url))
 
       {:redirect_301, url} ->
-        conn
-        |> put_status(301)
-        |> redirect(to: url)
+        redirect_301(conn, url)
 
       {:error, reason} ->
         handle_not_found(conn, reason)
@@ -362,6 +356,22 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
   defp set_gettext_locale(language) do
     Gettext.put_locale(PhoenixKitWeb.Gettext, language)
   end
+
+  # Issue the canonical 301 while preserving the request's query string — a
+  # `?utm_source=…` link that hits a canonical/locale redirect must not have its
+  # campaign params stripped.
+  defp redirect_301(conn, url) do
+    conn
+    |> put_status(301)
+    |> redirect(to: with_query_string(conn, url))
+  end
+
+  defp with_query_string(%{query_string: qs}, url) when is_binary(qs) and qs != "" do
+    separator = if String.contains?(url, "?"), do: "&", else: "?"
+    url <> separator <> qs
+  end
+
+  defp with_query_string(_conn, url), do: url
 
   defp build_og_data(conn, post, canonical_url, language) do
     description = Map.get(post.metadata, :description)

--- a/lib/phoenix_kit_publishing/web/controller.ex
+++ b/lib/phoenix_kit_publishing/web/controller.ex
@@ -203,14 +203,12 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> assign(:group, assigns.group)
         |> assign(:posts, assigns.posts)
         |> assign(:current_language, assigns.current_language)
-        |> assign(:translations, assigns.translations)
-        |> assign_publishing_translations(assigns.translations)
+        |> assign_publishing_render_context(assigns.translations)
         |> assign(:page, assigns.page)
         |> assign(:per_page, assigns.per_page)
         |> assign(:total_count, assigns.total_count)
         |> assign(:total_pages, assigns.total_pages)
         |> assign(:breadcrumbs, assigns.breadcrumbs)
-        |> assign(:show_language_switcher, show_language_switcher?())
         |> assign(:og, %{
           title: assigns.group["name"],
           url: base_url <> listing_url,
@@ -250,11 +248,9 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> assign(:post, assigns.post)
         |> assign(:html_content, assigns.html_content)
         |> assign(:current_language, assigns.current_language)
-        |> assign(:translations, assigns.translations)
-        |> assign_publishing_translations(assigns.translations)
+        |> assign_publishing_render_context(assigns.translations)
         |> assign(:breadcrumbs, assigns.breadcrumbs)
         |> assign(:version_dropdown, assigns.version_dropdown)
-        |> assign(:show_language_switcher, show_language_switcher?())
         |> assign(:og, build_og_data(conn, assigns.post, canonical_url, assigns.current_language))
         |> maybe_assign_admin_edit(
           edit_post_admin_url(group_slug, assigns.post.uuid, assigns.current_language),
@@ -282,15 +278,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> assign(:post, assigns.post)
         |> assign(:html_content, assigns.html_content)
         |> assign(:current_language, assigns.current_language)
-        |> assign(:translations, assigns.translations)
-        |> assign_publishing_translations(assigns.translations)
+        |> assign_publishing_render_context(assigns.translations)
         |> assign(:breadcrumbs, assigns.breadcrumbs)
         |> assign(:canonical_url, assigns.canonical_url)
         |> assign(:is_versioned_view, assigns.is_versioned_view)
         |> assign(:is_live_version, assigns.is_live_version)
         |> assign(:version, assigns.version)
         |> assign(:version_dropdown, assigns.version_dropdown)
-        |> assign(:show_language_switcher, show_language_switcher?())
         |> assign(
           :og,
           build_og_data(conn, assigns.post, assigns.canonical_url, assigns.current_language)
@@ -315,11 +309,9 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
         |> assign(:post, assigns.post)
         |> assign(:html_content, assigns.html_content)
         |> assign(:current_language, assigns.current_language)
-        |> assign(:translations, assigns.translations)
-        |> assign_publishing_translations(assigns.translations)
+        |> assign_publishing_render_context(assigns.translations)
         |> assign(:breadcrumbs, assigns.breadcrumbs)
         |> assign(:version_dropdown, assigns.version_dropdown)
-        |> assign(:show_language_switcher, show_language_switcher?())
         |> assign(:og, build_og_data(conn, assigns.post, canonical_url, assigns.current_language))
         |> maybe_assign_admin_edit(
           edit_post_admin_url(group_slug, assigns.post.uuid, assigns.current_language),
@@ -449,6 +441,19 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller do
   # switcher. We normalise to a fixed 5-field shape at the boundary so the
   # public contract is uniform across listing and post routes.
   #
+  # Assigns the render context shared by every public render branch (group
+  # listing, post, versioned post, date-only): the raw `:translations` the
+  # in-page switcher template reads, the normalized
+  # `:phoenix_kit_publishing_translations` host-integration assign, and the
+  # `:show_language_switcher` toggle. Extracted so the four branches can't
+  # drift on this block (PR #15 follow-up).
+  defp assign_publishing_render_context(conn, translations) do
+    conn
+    |> assign(:translations, translations)
+    |> assign_publishing_translations(translations)
+    |> assign(:show_language_switcher, show_language_switcher?())
+  end
+
   # `translations` is always a list — `Translations.build_listing_translations/3`
   # and `build_translation_links/4` are the only producers and both return
   # lists unconditionally. No fallback clause: if that contract is ever

--- a/lib/phoenix_kit_publishing/web/controller/fallback.ex
+++ b/lib/phoenix_kit_publishing/web/controller/fallback.ex
@@ -30,6 +30,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.Fallback do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.Constants
   alias PhoenixKit.Modules.Publishing.Web.Controller.Language
   alias PhoenixKit.Modules.Publishing.Web.Controller.Listing
   alias PhoenixKit.Modules.Publishing.Web.HTML, as: PublishingHTML
@@ -100,6 +101,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.Fallback do
   # manifests acutely when url_prefix == "/" and the catch-all sits at
   # the host's root, where /about, /contact, etc. would otherwise be hijacked).
   defp handle_fallback_case(:group_not_found, _path, _language), do: :no_fallback
+
+  # Module/public access disabled — render 404, never redirect. The group still
+  # exists in the DB, so the generic group-listing fallback below would 302 to the
+  # same disabled URL forever. Must precede the catch-all.
+  defp handle_fallback_case(:module_disabled, _path, _language), do: :no_fallback
 
   # Any post-level error with a 2+ segment path — fall back to group listing
   # Catches errors like :invalid_version, unknown reasons from read_post, etc.
@@ -323,14 +329,25 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.Fallback do
     identifier = "#{date}/#{time}"
 
     Enum.find_value(languages, fn lang ->
-      case Publishing.read_post(group_slug, identifier, lang) do
-        {:ok, post} when post.metadata.status == "published" ->
-          {:ok, build_timestamp_url(group_slug, date, time, lang)}
-
-        _ ->
-          nil
-      end
+      published_timestamp_url(group_slug, identifier, date, time, lang)
     end) || :not_found
+  end
+
+  # A future-dated post is 404'd as :unpublished by the renderer, so it must NOT
+  # be a fallback target either — otherwise two languages of the same future post
+  # 302-ping-pong between each other forever.
+  defp published_timestamp_url(group_slug, identifier, date, time, lang) do
+    with {:ok, post} <- Publishing.read_post(group_slug, identifier, lang),
+         true <- post.metadata.status == "published" and not future_timestamp_post?(post) do
+      {:ok, build_timestamp_url(group_slug, date, time, lang)}
+    else
+      _ -> nil
+    end
+  end
+
+  defp future_timestamp_post?(post) do
+    Constants.timestamp_mode?(post[:mode]) and post[:date] != nil and
+      Date.compare(post[:date], Date.utc_today()) == :gt
   end
 
   # ============================================================================

--- a/lib/phoenix_kit_publishing/web/controller/language.ex
+++ b/lib/phoenix_kit_publishing/web/controller/language.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.Language do
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
   alias PhoenixKit.Modules.Publishing.ListingCache
 
@@ -322,8 +323,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.Language do
         end)
 
       {:error, _} ->
-        # Cache miss - fall back to direct DB read
-        posts = Publishing.list_posts(group_slug, nil)
+        # Cache miss — fall back to the SAME source the cache is built from
+        # (active/published version), not list_posts/2 (latest, incl. drafts).
+        # This keeps "does this public group serve content for <language>?"
+        # answering on published content whether the cache is warm or not.
+        posts = DBStorage.list_posts_for_listing(group_slug)
 
         Enum.any?(posts, fn post ->
           language in (post.available_languages || [])

--- a/lib/phoenix_kit_publishing/web/controller/post_fetching.ex
+++ b/lib/phoenix_kit_publishing/web/controller/post_fetching.ex
@@ -11,6 +11,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.PostFetching do
   require Logger
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.ListingCache
 
   # ============================================================================
@@ -84,14 +85,19 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.PostFetching do
           "[PublishingController] Cache regeneration in progress for #{group_slug}, using direct DB read (#{elapsed_ms}ms)"
         )
 
-        Publishing.list_posts(group_slug, nil)
+        # Use the SAME source the cache is built from (active/published version,
+        # listing shape) rather than list_posts/2, which surfaces the LATEST
+        # (possibly draft) version. Otherwise a concurrent loser of a cold
+        # regeneration would briefly serve draft content — or drop a published
+        # post whose latest version is an unpublished draft — on the public listing.
+        DBStorage.list_posts_for_listing(group_slug)
 
       {:error, reason} ->
         Logger.error(
           "[PublishingController] Cache regeneration failed for #{group_slug}: #{inspect(reason)}"
         )
 
-        Publishing.list_posts(group_slug, nil)
+        DBStorage.list_posts_for_listing(group_slug)
     end
   end
 
@@ -105,7 +111,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.PostFetching do
           "[PublishingController] Cache read failed after regeneration for #{group_slug}: #{inspect(reason)}"
         )
 
-        Publishing.list_posts(group_slug, nil)
+        DBStorage.list_posts_for_listing(group_slug)
     end
   end
 end

--- a/lib/phoenix_kit_publishing/web/controller/slug_resolution.ex
+++ b/lib/phoenix_kit_publishing/web/controller/slug_resolution.ex
@@ -46,9 +46,18 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.SlugResolution do
         # Not found in current slugs - check previous slugs for 301 redirect
         case Publishing.find_by_previous_url_slug(group_slug, db_language, url_slug) do
           {:ok, cached_post} ->
-            # Found in previous slugs - redirect to current URL
+            # Found in previous slugs - redirect to current URL. The cache path
+            # carries `:language_slugs`; the DB path (db_content_to_post_map/1)
+            # does not, so fall back to the row's own `:url_slug` (the canonical
+            # custom slug for this language, which the DB map DOES carry) before
+            # the internal `:slug`. Without this, a post with a custom url_slug
+            # 301s to /group/<internal-slug> instead of the canonical URL.
             current_url_slug =
-              Map.get(cached_post[:language_slugs] || %{}, db_language, cached_post.slug)
+              Map.get(
+                cached_post[:language_slugs] || %{},
+                db_language,
+                cached_post[:url_slug] || cached_post.slug
+              )
 
             redirect_url =
               build_post_redirect_url(group_slug, cached_post, language, current_url_slug)
@@ -89,14 +98,19 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.SlugResolution do
   Builds redirect URL for 301 redirects from cached post data.
   """
   def build_post_redirect_url(group_slug, cached_post, language, url_slug) do
-    # Build post struct with minimal fields needed for URL generation
+    # Build post struct with minimal fields needed for URL generation.
+    # `cached_post` may be cache-shaped (carries :mode/:date/:time/:language_slugs)
+    # or DB-shaped (db_content_to_post_map/1 — only :slug/:url_slug/:language/:metadata),
+    # so read the cache-only fields with bracket access + sane fallbacks. This path
+    # is only reached for slug-mode resolution, so "slug" is the correct default mode
+    # and a nil date/time is never consulted by build_post_url/4 in that branch.
     post = %{
       slug: cached_post.slug,
       url_slug: url_slug,
-      mode: cached_post.mode,
-      date: cached_post.date,
-      time: cached_post.time,
-      language_slugs: cached_post.language_slugs
+      mode: Map.get(cached_post, :mode, "slug"),
+      date: cached_post[:date],
+      time: cached_post[:time],
+      language_slugs: cached_post[:language_slugs] || %{}
     }
 
     PublishingHTML.build_post_url(group_slug, post, language)

--- a/lib/phoenix_kit_publishing/web/controller/slug_resolution.ex
+++ b/lib/phoenix_kit_publishing/web/controller/slug_resolution.ex
@@ -95,7 +95,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.SlugResolution do
   # ============================================================================
 
   @doc """
-  Builds redirect URL for 301 redirects from cached post data.
+  Builds a 301 redirect URL from a resolved post map.
+
+  Accepts both the cache-shaped map (carries :mode/:date/:time/:language_slugs)
+  and the DB-shaped map from `db_content_to_post_map/1` (only :slug/:url_slug/
+  :language/:metadata), reading the cache-only fields defensively.
   """
   def build_post_redirect_url(group_slug, cached_post, language, url_slug) do
     # Build post struct with minimal fields needed for URL generation.

--- a/lib/phoenix_kit_publishing/web/controller/slug_resolution.ex
+++ b/lib/phoenix_kit_publishing/web/controller/slug_resolution.ex
@@ -102,12 +102,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.SlugResolution do
   :language/:metadata), reading the cache-only fields defensively.
   """
   def build_post_redirect_url(group_slug, cached_post, language, url_slug) do
-    # Build post struct with minimal fields needed for URL generation.
-    # `cached_post` may be cache-shaped (carries :mode/:date/:time/:language_slugs)
-    # or DB-shaped (db_content_to_post_map/1 — only :slug/:url_slug/:language/:metadata),
-    # so read the cache-only fields with bracket access + sane fallbacks. This path
-    # is only reached for slug-mode resolution, so "slug" is the correct default mode
-    # and a nil date/time is never consulted by build_post_url/4 in that branch.
+    # Build post struct with minimal fields needed for URL generation. Both the
+    # cache shape and the DB shape (db_content_to_post_map/1) now carry
+    # :mode/:date/:time, so the redirect resolves to the correct canonical URL
+    # for timestamp-mode posts too. Bracket access + a "slug" fallback are kept
+    # purely as defence against an unexpectedly sparse map.
     post = %{
       slug: cached_post.slug,
       url_slug: url_slug,

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -192,18 +192,36 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   # UUID-based route: /admin/publishing/:group/:post_uuid/edit
   def handle_params(%{"post_uuid" => post_uuid} = params, uri, socket)
       when not is_map_key(params, "preview_token") do
-    socket = assign(socket, :endpoint_url, extract_endpoint_url(uri))
+    socket =
+      socket
+      |> assign(:endpoint_url, extract_endpoint_url(uri))
+      |> reset_translation_state()
+
     handle_uuid_post_params(socket, post_uuid, params)
   end
 
   def handle_params(%{"path" => path} = params, uri, socket)
       when not is_map_key(params, "preview_token") do
-    socket = assign(socket, :endpoint_url, extract_endpoint_url(uri))
+    socket =
+      socket
+      |> assign(:endpoint_url, extract_endpoint_url(uri))
+      |> reset_translation_state()
+
     handle_path_post_params(socket, path, params)
   end
 
   def handle_params(_params, _uri, socket) do
     {:noreply, socket}
+  end
+
+  # Clear any in-flight translation lock/spinner when (re)loading a post scope.
+  # A version or language switch patches through handle_params, but completion
+  # events for the PREVIOUS scope are deliberately ignored — so without this the
+  # editor would stay locked behind a spinner until a full remount.
+  defp reset_translation_state(socket) do
+    socket
+    |> assign(:translation_locked?, false)
+    |> assign(:ai_translation_progress, nil)
   end
 
   # Derive the public-facing origin (scheme://host[:port]) from the current

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -1002,9 +1002,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     post = socket.assigns.post
     language = socket.assigns.current_language
     post_uuid = post[:uuid]
+    # Target the version the editor is actually on, not whatever is newest —
+    # otherwise clearing a translation while viewing/editing an older version
+    # hard-deletes the language row from the wrong (e.g. live) version.
+    version = socket.assigns[:current_version]
 
     result =
-      Publishing.clear_translation(group_slug, post_uuid, language,
+      Publishing.clear_translation(group_slug, post_uuid, language, version,
         actor_uuid: Shared.actor_uuid_from_socket(socket)
       )
 

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -803,15 +803,23 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   end
 
   def handle_event("translate_to_all_languages", _params, socket) do
-    target_languages = Translation.get_all_target_languages(socket)
-    empty_opts = {:warning, gettext("No other languages enabled to translate to")}
-    Translation.enqueue_translation(socket, target_languages, empty_opts)
+    if socket.assigns[:readonly?] do
+      {:noreply, socket}
+    else
+      target_languages = Translation.get_all_target_languages(socket)
+      empty_opts = {:warning, gettext("No other languages enabled to translate to")}
+      Translation.enqueue_translation(socket, target_languages, empty_opts)
+    end
   end
 
   def handle_event("translate_missing_languages", _params, socket) do
-    target_languages = Translation.get_target_languages_for_translation(socket)
-    empty_opts = {:info, gettext("All languages already have translations")}
-    Translation.enqueue_translation(socket, target_languages, empty_opts)
+    if socket.assigns[:readonly?] do
+      {:noreply, socket}
+    else
+      target_languages = Translation.get_target_languages_for_translation(socket)
+      empty_opts = {:info, gettext("All languages already have translations")}
+      Translation.enqueue_translation(socket, target_languages, empty_opts)
+    end
   end
 
   def handle_event("translate_to_this_language", _params, socket) do
@@ -820,6 +828,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     else
       Translation.start_translation_to_current(socket)
     end
+  end
+
+  def handle_event("confirm_translation", _params, socket)
+      when socket.assigns.readonly? == true do
+    {:noreply, socket}
   end
 
   def handle_event("confirm_translation", _params, socket) do
@@ -928,6 +941,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     end
   end
 
+  def handle_event("create_version_from_source", _params, socket)
+      when socket.assigns.readonly? == true do
+    {:noreply, socket}
+  end
+
   def handle_event("create_version_from_source", _params, socket) do
     case Versions.create_version_from_source(socket) do
       {:ok, socket} -> {:noreply, socket}
@@ -953,9 +971,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   # ============================================================================
 
   def handle_event("preview", _params, socket) do
-    # Save first if there are pending changes (autosave is 500ms but user might click fast)
+    # Save first if there are pending changes (autosave is 500ms but user might click fast).
+    # Never save for a read-only spectator — they always read has_pending_changes: true
+    # after a remote sync, so an unguarded save here would clobber the lock owner's work.
     socket =
-      if socket.assigns.has_pending_changes do
+      if socket.assigns.has_pending_changes and not socket.assigns[:readonly?] do
         {:noreply, saved} = Persistence.perform_save(socket)
         saved
       else
@@ -1175,7 +1195,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
 
   @impl true
   def handle_info(:autosave, socket) do
-    if socket.assigns.has_pending_changes and not socket.assigns.translation_locked? do
+    # A read-only spectator must never autosave — their buffer is stale and would
+    # clobber the lock owner's work. translation_locked? alone didn't cover them.
+    if socket.assigns.has_pending_changes and not socket.assigns.translation_locked? and
+         not socket.assigns[:readonly?] do
       socket =
         socket
         |> assign(:is_autosaving, true)
@@ -1223,17 +1246,24 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   end
 
   def handle_info({:editor_content_changed, %{content: content}}, socket) do
-    has_changes = Forms.dirty?(socket.assigns.post, socket.assigns.form, content)
+    # Ignore local editor changes for read-only spectators: their content arrives
+    # via remote sync, and marking pending / scheduling autosave here is a write
+    # path that would let a spectator's stale buffer overwrite the lock owner.
+    if socket.assigns[:readonly?] do
+      {:noreply, socket}
+    else
+      has_changes = Forms.dirty?(socket.assigns.post, socket.assigns.form, content)
 
-    socket =
-      socket
-      |> assign(:content, content)
-      |> assign(:has_pending_changes, has_changes)
-      |> push_event("changes-status", %{has_changes: has_changes})
+      socket =
+        socket
+        |> assign(:content, content)
+        |> assign(:has_pending_changes, has_changes)
+        |> push_event("changes-status", %{has_changes: has_changes})
 
-    socket = if has_changes, do: schedule_autosave(socket), else: socket
+      socket = if has_changes, do: schedule_autosave(socket), else: socket
 
-    {:noreply, socket}
+      {:noreply, socket}
+    end
   end
 
   def handle_info({:editor_insert_component, %{type: :image}}, socket) do
@@ -1711,11 +1741,21 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     assign(socket, :autosave_timer, timer_ref)
   end
 
-  defp re_read_post(socket, language) do
+  defp re_read_post(socket, language, version \\ nil) do
     case socket.assigns[:post] do
-      nil -> {:error, :no_post}
-      %{uuid: nil} -> {:error, :no_uuid}
-      post -> Publishing.read_post_by_uuid(post.uuid, language)
+      nil ->
+        {:error, :no_post}
+
+      %{uuid: nil} ->
+        {:error, :no_uuid}
+
+      post ->
+        # Default to the version the editor is pinned to, not the latest — reloads
+        # (lock acquisition, translation-created updates) run while pinned to an
+        # older version, and reading the latest would load the wrong version's
+        # content under a URL claiming the pinned one and misdirect the next save.
+        version = version || socket.assigns[:current_version]
+        Publishing.read_post_by_uuid(post.uuid, language, version)
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -906,41 +906,48 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
   end
 
   def handle_event("switch_version", %{"version" => version_str}, socket) do
-    version = String.to_integer(version_str)
+    # Parse defensively — a hand-crafted `?v=abc` would otherwise crash the LV on
+    # String.to_integer/1 (L1). parse_version_param/1 returns nil on junk.
+    version = parse_version_param(version_str)
 
-    if version == socket.assigns.current_version do
-      {:noreply, socket}
-    else
-      case Versions.read_version_post(socket, version) do
-        {:ok, version_post} ->
-          {socket, old_form_key, old_post_slug, new_form_key, actual_language} =
-            Versions.apply_version_switch(
-              socket,
-              version,
-              version_post,
-              &Forms.post_form_with_primary_status/3
-            )
+    cond do
+      is_nil(version) ->
+        {:noreply, put_flash(socket, :error, gettext("Version not found"))}
 
-          socket =
-            socket
-            |> Helpers.assign_current_language(actual_language)
-            |> Collaborative.cleanup_and_setup_collaborative_editing(old_form_key, new_form_key,
-              old_post_slug: old_post_slug
-            )
+      version == socket.assigns.current_version ->
+        {:noreply, socket}
 
-          post = socket.assigns.post
+      true ->
+        case Versions.read_version_post(socket, version) do
+          {:ok, version_post} ->
+            {socket, old_form_key, old_post_slug, new_form_key, actual_language} =
+              Versions.apply_version_switch(
+                socket,
+                version,
+                version_post,
+                &Forms.post_form_with_primary_status/3
+              )
 
-          url =
-            Helpers.build_edit_url(socket.assigns.group_slug, post,
-              version: version,
-              lang: actual_language
-            )
+            socket =
+              socket
+              |> Helpers.assign_current_language(actual_language)
+              |> Collaborative.cleanup_and_setup_collaborative_editing(old_form_key, new_form_key,
+                old_post_slug: old_post_slug
+              )
 
-          {:noreply, push_patch(socket, to: url, replace: true)}
+            post = socket.assigns.post
 
-        {:error, _reason} ->
-          {:noreply, put_flash(socket, :error, gettext("Version not found"))}
-      end
+            url =
+              Helpers.build_edit_url(socket.assigns.group_slug, post,
+                version: version,
+                lang: actual_language
+              )
+
+            {:noreply, push_patch(socket, to: url, replace: true)}
+
+          {:error, _reason} ->
+            {:noreply, put_flash(socket, :error, gettext("Version not found"))}
+        end
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -241,6 +241,20 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
 
   defp extract_endpoint_url(_), do: ""
 
+  # Resolve a post by UUID but require it to belong to the group in the URL.
+  # read_post_by_uuid/3 resolves purely by UUID, so without this the editor would
+  # load a post from another group and then validate slug uniqueness against the
+  # wrong group — letting it mint duplicate slugs in the real group (M6).
+  defp read_post_by_uuid_in_group(post_uuid, group_slug, language, version) do
+    case Publishing.read_post_by_uuid(post_uuid, language, version) do
+      {:ok, post} ->
+        if post[:group] == group_slug, do: {:ok, post}, else: {:error, :wrong_group}
+
+      other ->
+        other
+    end
+  end
+
   defp handle_uuid_post_params(socket, post_uuid, params) do
     group_slug = socket.assigns.group_slug
     group_mode = Publishing.get_group_mode(group_slug)
@@ -248,7 +262,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     version = parse_version_param(params["v"])
     language = params["lang"]
 
-    case Publishing.read_post_by_uuid(post_uuid, language, version) do
+    case read_post_by_uuid_in_group(post_uuid, group_slug, language, version) do
       {:ok, post} ->
         all_enabled_languages = Publishing.enabled_language_codes()
 

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -1022,28 +1022,20 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     # Save first if there are pending changes (autosave is 500ms but user might click fast).
     # Never save for a read-only spectator — they always read has_pending_changes: true
     # after a remote sync, so an unguarded save here would clobber the lock owner's work.
-    socket =
-      if socket.assigns.has_pending_changes and not socket.assigns[:readonly?] do
-        {:noreply, saved} = Persistence.perform_save(socket)
-        saved
+    if socket.assigns.has_pending_changes and not socket.assigns[:readonly?] do
+      {:noreply, saved} = Persistence.perform_save(socket)
+
+      # If the save didn't go through (a validation error or the url_slug-conflict
+      # modal left changes pending), stay on the editor and show that — don't
+      # navigate to a stale preview and silently drop the error/modal (L2).
+      if saved.assigns.has_pending_changes do
+        {:noreply, saved}
       else
-        socket
+        {:noreply, navigate_to_preview(saved)}
       end
-
-    group_slug = socket.assigns.group_slug
-    post = socket.assigns.post
-    post_uuid = post[:uuid]
-    language = socket.assigns.current_language
-    version = socket.assigns[:current_version]
-
-    query_params = %{"lang" => language}
-    query_params = if version, do: Map.put(query_params, "v", version), else: query_params
-    query = URI.encode_query(query_params)
-
-    {:noreply,
-     push_navigate(socket,
-       to: Routes.path("/admin/publishing/#{group_slug}/#{post_uuid}/preview?#{query}")
-     )}
+    else
+      {:noreply, navigate_to_preview(socket)}
+    end
   end
 
   def handle_event("attempt_cancel", _params, %{assigns: %{has_pending_changes: false}} = socket) do
@@ -1787,6 +1779,21 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
     # Save quickly — DB writes are ~5ms, no reason to delay
     timer_ref = Process.send_after(self(), :autosave, 500)
     assign(socket, :autosave_timer, timer_ref)
+  end
+
+  defp navigate_to_preview(socket) do
+    group_slug = socket.assigns.group_slug
+    post_uuid = socket.assigns.post[:uuid]
+    language = socket.assigns.current_language
+    version = socket.assigns[:current_version]
+
+    query_params = %{"lang" => language}
+    query_params = if version, do: Map.put(query_params, "v", version), else: query_params
+    query = URI.encode_query(query_params)
+
+    push_navigate(socket,
+      to: Routes.path("/admin/publishing/#{group_slug}/#{post_uuid}/preview?#{query}")
+    )
   end
 
   defp re_read_post(socket, language, version \\ nil) do
@@ -2609,6 +2616,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
                   id="title-input"
                   value={@form["title"] || ""}
                   maxlength="500"
+                  phx-debounce="300"
                   class={"input input-bordered w-full text-2xl font-semibold #{if edit_disabled? or @viewing_older_version, do: "input-disabled bg-base-200"}"}
                   placeholder={gettext("Post title")}
                   readonly={edit_disabled? or @viewing_older_version}

--- a/lib/phoenix_kit_publishing/web/editor.ex
+++ b/lib/phoenix_kit_publishing/web/editor.ex
@@ -138,6 +138,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
       |> assign(:viewing_older_version, false)
       |> assign(:show_new_version_modal, false)
       |> assign(:new_version_source, nil)
+      |> assign(:show_slug_conflict_modal, false)
+      |> assign(:slug_conflict_info, nil)
       |> assign(:show_ai_translation, false)
       |> assign(:ai_enabled, Code.ensure_loaded?(PhoenixKitAI) and AI.enabled?())
       |> assign(:ai_endpoints, Translation.list_ai_endpoints())
@@ -967,6 +969,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
      socket
      |> assign(:show_new_version_modal, false)
      |> assign(:new_version_source, nil)}
+  end
+
+  def handle_event("close_slug_conflict_modal", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_slug_conflict_modal, false)
+     |> assign(:slug_conflict_info, nil)}
   end
 
   def handle_event("set_new_version_source", %{"source" => "blank"}, socket) do
@@ -2997,6 +3006,50 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor do
         </div>
       </div>
       <div class="modal-backdrop bg-base-content/50" phx-click="close_new_version_modal"></div>
+    </div>
+    <% end %>
+
+    <%!-- URL Slug Conflict Modal --%>
+    <%= if @show_slug_conflict_modal and @slug_conflict_info do %>
+    <div class="modal modal-open">
+      <div class="modal-box max-w-md">
+        <h3 class="font-bold text-lg mb-2 flex items-center gap-2">
+          <.icon name="hero-exclamation-triangle" class="w-5 h-5 text-warning" />
+          {gettext("URL slug already in use")}
+        </h3>
+
+        <p class="text-sm text-base-content/80 mb-3">
+          {gettext("The URL slug %{slug} is already used by another post in this group:",
+            slug: "“#{@slug_conflict_info.slug}”"
+          )}
+        </p>
+
+        <div class="rounded-lg border border-base-300 bg-base-200 p-3 mb-4">
+          <p class="font-medium">
+            {@slug_conflict_info.title || gettext("Another post")}
+          </p>
+          <%= if @slug_conflict_info.edit_url do %>
+          <.link
+            navigate={@slug_conflict_info.edit_url}
+            class="link link-primary text-sm inline-flex items-center gap-1 mt-1"
+          >
+            <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" />
+            {gettext("Open that post")}
+          </.link>
+          <% end %>
+        </div>
+
+        <p class="text-sm text-base-content/70 mb-4">
+          {gettext("Choose a different URL slug for this post, or change the other post's slug.")}
+        </p>
+
+        <div class="modal-action">
+          <button type="button" class="btn btn-primary" phx-click="close_slug_conflict_modal">
+            {gettext("OK")}
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop bg-base-content/50" phx-click="close_slug_conflict_modal"></div>
     </div>
     <% end %>
 

--- a/lib/phoenix_kit_publishing/web/editor/forms.ex
+++ b/lib/phoenix_kit_publishing/web/editor/forms.ex
@@ -304,30 +304,24 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Forms do
 
   defp no_slug_update(socket), do: {socket, socket.assigns.form, []}
 
-  # Auto-generated slugs never error — they truncate to fit. When the title was
-  # too long to fully fit, warn ONCE (a false->true transition on
-  # `:slug_truncated`) so live typing past the cap doesn't spam a flash on every
-  # keystroke. The warning clears when the title shrinks back under the cap.
+  # Auto-generated slugs never error — they truncate to fit. While the title is
+  # over the URL cap, keep the warning present: `update_meta` clear_flash's up
+  # front on every keystroke, so we must re-assert it each time the slug is
+  # still truncated (a once-only false->true guard let an unrelated keystroke
+  # wipe the warning while the slug was still cut). It clears when the title
+  # shrinks back under the cap.
   defp maybe_warn_slug_truncated(socket, title) do
-    truncated? = Publishing.slug_truncated?(title)
-    already? = Map.get(socket.assigns, :slug_truncated, false)
-
-    cond do
-      truncated? and not already? ->
-        socket
-        |> Phoenix.Component.assign(:slug_truncated, true)
-        |> Phoenix.LiveView.put_flash(
-          :warning,
-          gettext(
-            "The title was too long for a URL, so the slug was shortened. Edit it manually if you'd like a different one."
-          )
+    if Publishing.slug_truncated?(title) do
+      socket
+      |> Phoenix.Component.assign(:slug_truncated, true)
+      |> Phoenix.LiveView.put_flash(
+        :warning,
+        gettext(
+          "The title was too long for a URL, so the slug was shortened. Edit it manually if you'd like a different one."
         )
-
-      not truncated? ->
-        Phoenix.Component.assign(socket, :slug_truncated, false)
-
-      true ->
-        socket
+      )
+    else
+      Phoenix.Component.assign(socket, :slug_truncated, false)
     end
   end
 

--- a/lib/phoenix_kit_publishing/web/editor/helpers.ex
+++ b/lib/phoenix_kit_publishing/web/editor/helpers.ex
@@ -186,7 +186,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Helpers do
   sanitised so it can't break out of the XML attribute.
   """
   def image_component_markup(file_uuid) when is_binary(file_uuid) do
-    ~s(\n<Image file_uuid="#{file_uuid}" alt="#{alt_from_file(file_uuid)}"/>\n)
+    # The uuid comes from the server-side media picker, so it's a real UUID in
+    # practice — but strip anything outside the UUID charset before interpolating
+    # into markup that flows through the `escape: false` renderer, so the insert
+    # path stays safe even if it ever accepts a less-trusted id. (alt text is
+    # already sanitised in alt_from_filename/1.)
+    safe_uuid = String.replace(file_uuid, ~r/[^0-9a-fA-F-]/, "")
+    ~s(\n<Image file_uuid="#{safe_uuid}" alt="#{alt_from_file(file_uuid)}"/>\n)
   end
 
   defp alt_from_file(file_uuid) do

--- a/lib/phoenix_kit_publishing/web/editor/persistence.ex
+++ b/lib/phoenix_kit_publishing/web/editor/persistence.ex
@@ -175,6 +175,12 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   defp url_slug_error_message(:reserved_route_word),
     do: gettext("URL slug cannot be a reserved word (admin, api, assets, etc.)")
 
+  defp url_slug_error_message(:conflicts_with_previous_slug),
+    do:
+      gettext(
+        "URL slug is a previous address of another post — using it would hijack that post's redirect"
+      )
+
   defp do_perform_save(socket, params) do
     is_new_post = Map.get(socket.assigns, :is_new_post, false)
     is_new_translation = Map.get(socket.assigns, :is_new_translation, false)

--- a/lib/phoenix_kit_publishing/web/editor/persistence.ex
+++ b/lib/phoenix_kit_publishing/web/editor/persistence.ex
@@ -755,6 +755,12 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
 
   defp re_read_post(socket, language \\ nil, version \\ nil) do
     post = socket.assigns.post
+    # Default to the editor's pinned version (current_version), not the latest —
+    # reload_post/reload_translated_content/refresh_available_languages all run
+    # while pinned to a specific version, and reading the latest would load the
+    # wrong version's content and misdirect the next save (commit 59381a3's bug,
+    # surviving in these sibling reload paths).
+    version = version || socket.assigns[:current_version]
     Publishing.read_post_by_uuid(post.uuid, language, version)
   end
 

--- a/lib/phoenix_kit_publishing/web/editor/persistence.ex
+++ b/lib/phoenix_kit_publishing/web/editor/persistence.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
@@ -88,6 +89,15 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
         socket = Phoenix.LiveView.put_flash(socket, :info, notice)
         do_perform_save(socket, validated_params)
 
+      {:slug_conflict, info} ->
+        # Don't silently clear or save — show the user which post owns the slug
+        # (with a link) so they can rename theirs or jump to the other one. The
+        # form keeps their typed slug so they can edit it after closing.
+        {:noreply,
+         socket
+         |> Phoenix.Component.assign(:slug_conflict_info, info)
+         |> Phoenix.Component.assign(:show_slug_conflict_modal, true)}
+
       {:error, reason} ->
         error_message = url_slug_error_message(reason)
         {:noreply, Phoenix.LiveView.put_flash(socket, :error, error_message)}
@@ -110,20 +120,30 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
           auto_clear_and_notify(params, group_slug, post_slug, url_slug, language, :conflicts)
 
         {:error, :slug_already_exists} ->
-          auto_clear_and_notify(
-            params,
-            group_slug,
-            post_slug,
-            url_slug,
-            language,
-            :already_exists
-          )
+          {:slug_conflict, build_slug_conflict_info(group_slug, url_slug, language)}
 
         {:error, reason} ->
           {:error, reason}
       end
     else
       {:ok, params}
+    end
+  end
+
+  # Look up the post that already owns `url_slug` so the conflict modal can name
+  # it and link to it (drafts included). Degrades to a title-less notice if the
+  # owner can't be resolved.
+  defp build_slug_conflict_info(group_slug, url_slug, language) do
+    case DBStorage.find_by_url_slug_any_version(group_slug, language, url_slug) do
+      %{title: title, version: %{post: %{uuid: uuid}}} ->
+        %{
+          slug: url_slug,
+          title: title,
+          edit_url: Helpers.build_edit_url(group_slug, %{uuid: uuid})
+        }
+
+      _ ->
+        %{slug: url_slug, title: nil, edit_url: nil}
     end
   end
 
@@ -145,22 +165,6 @@ defmodule PhoenixKit.Modules.Publishing.Web.Editor.Persistence do
   defp slug_cleared_notice(:conflicts, slug, language, _count) do
     gettext(
       "Custom URL slug '%{slug}' for %{language} was cleared because it conflicts with another post's post slug",
-      slug: slug,
-      language: language
-    )
-  end
-
-  defp slug_cleared_notice(:already_exists, slug, _language, count) when count > 1 do
-    gettext(
-      "Custom URL slug '%{slug}' was cleared from %{count} translations because it's already in use by another post",
-      slug: slug,
-      count: count
-    )
-  end
-
-  defp slug_cleared_notice(:already_exists, slug, language, _count) do
-    gettext(
-      "Custom URL slug '%{slug}' for %{language} was cleared because it's already in use by another post",
       slug: slug,
       language: language
     )

--- a/lib/phoenix_kit_publishing/web/index.ex
+++ b/lib/phoenix_kit_publishing/web/index.ex
@@ -15,7 +15,6 @@ defmodule PhoenixKit.Modules.Publishing.Web.Index do
 
   @group_statuses Constants.group_statuses()
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
-  alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Shared
   alias PhoenixKit.Modules.Publishing.Web.HTML, as: PublishingHTML
@@ -278,12 +277,12 @@ defmodule PhoenixKit.Modules.Publishing.Web.Index do
   defp build_group_insight(db_group, current_user, date_time_settings) do
     group_slug = db_group["slug"]
 
-    # Use ListingCache when available (sub-microsecond), fall back to DB
-    posts =
-      case ListingCache.read(group_slug) do
-        {:ok, cached_posts} -> cached_posts
-        {:error, _} -> Publishing.list_posts(group_slug)
-      end
+    # Always read from the DB (all non-trashed posts, including drafts). The
+    # ListingCache is built from active/published versions only, so a warm-cache
+    # read would silently zero out the draft/scheduled counts this admin insight
+    # exists to show — making the same widget report different numbers depending
+    # on cache warmth.
+    posts = Publishing.list_posts(group_slug)
 
     status_counts = Enum.frequencies_by(posts, &Map.get(&1[:metadata] || %{}, :status, "draft"))
 

--- a/lib/phoenix_kit_publishing/web/listing.ex
+++ b/lib/phoenix_kit_publishing/web/listing.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.Listing do
   alias PhoenixKit.Modules.Publishing
   alias PhoenixKit.Modules.Publishing.Errors
   alias PhoenixKit.Modules.Publishing.LanguageHelpers
+  alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.PubSub, as: PublishingPubSub
   alias PhoenixKit.Modules.Publishing.Shared
   alias PhoenixKit.Modules.Publishing.StaleFixer
@@ -322,8 +323,13 @@ defmodule PhoenixKit.Modules.Publishing.Web.Listing do
     {:noreply, socket}
   end
 
-  def handle_info({:cache_changed, _group_slug}, socket) do
-    {:noreply, socket}
+  def handle_info({:cache_changed, group_slug}, socket) do
+    # The listing cache is node-local (:persistent_term), so a mutation on another
+    # node leaves this node's cache stale. This broadcast is cluster-wide, so
+    # regenerate THIS node's cache (idempotent + lock-deduped) and refresh the view.
+    # Single-node: harmless — the mutating node already regenerated in-process.
+    ListingCache.regenerate(group_slug)
+    {:noreply, refresh_posts(socket)}
   end
 
   # Editor presence handlers - show who's currently editing posts

--- a/lib/phoenix_kit_publishing/web/settings.ex
+++ b/lib/phoenix_kit_publishing/web/settings.ex
@@ -129,16 +129,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Settings do
     new_value = !socket.assigns.memory_cache_enabled
     Settings.update_setting(@memory_cache_key, to_string(new_value))
 
-    # If disabling memory cache, clear all :persistent_term entries
-    if !new_value do
-      Enum.each(socket.assigns.cache_groups, fn group ->
-        try do
-          :persistent_term.erase(ListingCache.persistent_term_key(group["slug"]))
-        rescue
-          ArgumentError -> :ok
-        end
-      end)
-    end
+    # If disabling memory cache, erase ALL listing-cache entries (every group +
+    # all three persistent_term prefixes) so a later re-enable can't serve stale
+    # pre-disable data. The old loop only cleared the posts key for the groups it
+    # happened to have loaded (L7).
+    if !new_value, do: ListingCache.erase_all()
 
     {:noreply,
      socket

--- a/phk-publishing-format.md
+++ b/phk-publishing-format.md
@@ -61,7 +61,7 @@ Only a subset is required, but the publishing UI will populate everything shown 
 After the frontmatter, everything is standard Markdown. The renderer automatically:
 
 1. Runs Markdown through Earmark (GitHub-flavoured Markdown).
-2. Scans for inline PHK components (`<Image />`, `<Hero>…</Hero>`, `<CTA />`, `<Headline>`, `<Subheadline>`).
+2. Scans for inline PHK components (`<Image />`, `<CTA />`, `<Headline>`, `<Subheadline>`, `<Video>`).
 3. Renders those components with Phoenix components before returning HTML.
 
 This means you can drop components alongside text:
@@ -80,7 +80,6 @@ You can mix **bold text** and inline components:
 | Component | Notes |
 |-----------|-------|
 | `<Image … />` | Works with either `src="/path/to/file.jpg"` or `file_uuid="…"`. Optional `file_variant="thumbnail" | "small" | "medium" | "large"` picks a specific variant from PhoenixKit Storage. The renderer now always returns the natural dimensions; add your own `class` if you want to constrain width. |
-| `<Hero variant="split-image|centered|minimal"> … </Hero>` | A layout block that can wrap `<Headline>`, `<Subheadline>`, `<CTA />`, `<Image />`. Use sparingly inside Markdown (usually near the top). |
 | `<Headline>…</Headline>` | Renders a hero-style heading. |
 | `<Subheadline>…</Subheadline>` | Medium-sized supporting text. |
 | `<CTA primary="true|false" action="/path-or-anchor">Label</CTA>` | Button styled by the admin theme. |
@@ -116,12 +115,10 @@ published_at: 2025-10-31T09:00:00Z
 
 Thanks for building with PhoenixKit! Here are the highlights from this month.
 
-<Hero variant="split-image">
-  <Headline>Maintenance Mode v2</Headline>
-  <Subheadline>Plan downtime with confidence.</Subheadline>
-  <CTA primary="true" action="/admin/modules">Enable Module</CTA>
-  <Image file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Maintenance Mode Screenshot" />
-</Hero>
+<Headline>Maintenance Mode v2</Headline>
+<Subheadline>Plan downtime with confidence.</Subheadline>
+<CTA primary="true" action="/admin/modules">Enable Module</CTA>
+<Image file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Maintenance Mode Screenshot" />
 
 ## New referral analytics
 
@@ -152,43 +149,35 @@ published_at: 2025-07-01T10:00:00Z
 # Working with PhoenixKit Storage
 
 <!-- Example 1: Using direct URL -->
-<Hero variant="split-image">
-  <Headline>Direct URL Image Example</Headline>
-  <Subheadline>This uses a direct asset path to display an image.</Subheadline>
-  <CTA primary="true" action="/signup">Get Started</CTA>
-  <Image src="/assets/dashboard-preview.png" alt="Dashboard Preview" />
-</Hero>
+<Headline>Direct URL Image Example</Headline>
+<Subheadline>This uses a direct asset path to display an image.</Subheadline>
+<CTA primary="true" action="/signup">Get Started</CTA>
+<Image src="/assets/dashboard-preview.png" alt="Dashboard Preview" />
 
 <!-- Example 2: Using file_uuid -->
-<Hero variant="centered">
-  <Headline>Storage File ID Example</Headline>
-  <Subheadline>This pulls from PhoenixKit Storage.</Subheadline>
-  <CTA primary="true" action="/upload">Upload Image</CTA>
-  <Image file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Uploaded Image" />
-</Hero>
+<Headline>Storage File ID Example</Headline>
+<Subheadline>This pulls from PhoenixKit Storage.</Subheadline>
+<CTA primary="true" action="/upload">Upload Image</CTA>
+<Image file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Uploaded Image" />
 
 <!-- Example 3: Using file_uuid with variant -->
-<Hero variant="minimal">
-  <Headline>Thumbnail Variant</Headline>
-  <Subheadline>Great for small inline previews.</Subheadline>
-  <Image
-    file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890"
-    file_variant="thumbnail"
-    alt="Thumbnail Image"
-  />
-</Hero>
+<Headline>Thumbnail Variant</Headline>
+<Subheadline>Great for small inline previews.</Subheadline>
+<Image
+  file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890"
+  file_variant="thumbnail"
+  alt="Thumbnail Image"
+/>
 
 <!-- Example 4: Custom classes -->
-<Hero variant="split-image">
-  <Headline>Custom Styling</Headline>
-  <Subheadline>Combine variants with Tailwind utility classes.</Subheadline>
-  <Image
-    file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890"
-    file_variant="medium"
-    class="border-4 border-primary"
-    alt="Styled Image"
-  />
-</Hero>
+<Headline>Custom Styling</Headline>
+<Subheadline>Combine variants with Tailwind utility classes.</Subheadline>
+<Image
+  file_uuid="018e3c4a-9f6b-7890-abcd-ef1234567890"
+  file_variant="medium"
+  class="border-4 border-primary"
+  alt="Styled Image"
+/>
 ```
 
 ---

--- a/test/phoenix_kit_publishing/errors_test.exs
+++ b/test/phoenix_kit_publishing/errors_test.exs
@@ -128,6 +128,15 @@ defmodule PhoenixKit.Modules.Publishing.ErrorsTest do
       refute msg =~ "uuid"
     end
 
+    test "keeps acronyms uppercased instead of lowercasing them" do
+      # String.capitalize/1 would render these as "Url slug" / "Seo title".
+      assert Errors.message(changeset_with([{:url_slug, "is invalid"}])) ==
+               "URL slug is invalid"
+
+      assert Errors.message(changeset_with([{:seo_title, "is invalid"}])) ==
+               "SEO title is invalid"
+    end
+
     test "interpolates %{...} placeholders from error opts" do
       msg =
         Errors.message(

--- a/test/phoenix_kit_publishing/facade_callbacks_test.exs
+++ b/test/phoenix_kit_publishing/facade_callbacks_test.exs
@@ -38,6 +38,12 @@ defmodule PhoenixKit.Modules.Publishing.FacadeCallbacksTest do
       assert PhoenixKit.Modules.Publishing.Presence in children
     end
 
+    test "children declares the listing-cache lock-table owner (M8)" do
+      # The regeneration-lock ETS table must be owned by a supervised process,
+      # not a transient request process that dies and leaves it dangling.
+      assert PhoenixKit.Modules.Publishing.ListingCache.LockTableOwner in Publishing.children()
+    end
+
     test "children declares the :publishing_posts render cache with a bounded size" do
       # Regression: the render cache (Renderer.render_post_cached/1) was never
       # supervised, so caching silently no-op'd and every published view

--- a/test/phoenix_kit_publishing/facade_callbacks_test.exs
+++ b/test/phoenix_kit_publishing/facade_callbacks_test.exs
@@ -37,6 +37,24 @@ defmodule PhoenixKit.Modules.Publishing.FacadeCallbacksTest do
       children = Publishing.children()
       assert PhoenixKit.Modules.Publishing.Presence in children
     end
+
+    test "children declares the :publishing_posts render cache with a bounded size" do
+      # Regression: the render cache (Renderer.render_post_cached/1) was never
+      # supervised, so caching silently no-op'd and every published view
+      # re-rendered. The child must be declared with a name and a max_size bound.
+      children = Publishing.children()
+
+      cache_spec =
+        Enum.find(children, fn
+          %{start: {PhoenixKit.Cache, :start_link, _}} -> true
+          _ -> false
+        end)
+
+      assert cache_spec, "expected a PhoenixKit.Cache child in Publishing.children/0"
+      [opts] = elem(cache_spec.start, 2)
+      assert opts[:name] == :publishing_posts
+      assert is_integer(opts[:max_size]) and opts[:max_size] > 0
+    end
   end
 
   describe "permission_metadata/0" do

--- a/test/phoenix_kit_publishing/integration/db_storage_url_slug_lookup_test.exs
+++ b/test/phoenix_kit_publishing/integration/db_storage_url_slug_lookup_test.exs
@@ -294,36 +294,36 @@ defmodule PhoenixKit.Integration.Publishing.DBStorageUrlSlugLookupTest do
       {:ok, _} = DBStorage.update_content(newer_content, %{url_slug: "duplicate-slug"})
       :ok = Versions.publish_version(group["slug"], newer_post.uuid, newer_v.version_number)
 
-      # First call: newer post wins (order_by p.inserted_at DESC), older
-      # loses → its url_slug becomes "duplicate-slug-2".
+      # First call: the OLDER (incumbent) post wins (order_by p.uuid ASC), the
+      # newer one loses → its url_slug becomes "duplicate-slug-2".
       winner = DBStorage.find_by_url_slug(group["slug"], "en-US", "duplicate-slug")
       assert winner != nil
-      assert winner.version.post.slug == "newer-collider"
+      assert winner.version.post.slug == "older-collider"
 
-      # Loser's url_slug got renamed in place.
-      reloaded_older = DBStorage.list_contents(older_v.uuid) |> List.first()
-      assert reloaded_older.url_slug == "duplicate-slug-2"
+      # Loser (the NEWER post) got its url_slug renamed in place.
+      reloaded_newer = DBStorage.list_contents(newer_v.uuid) |> List.first()
+      assert reloaded_newer.url_slug == "duplicate-slug-2"
 
       # Subsequent lookup is clean — only one row matches "duplicate-slug".
       assert winner_again =
                DBStorage.find_by_url_slug(group["slug"], "en-US", "duplicate-slug")
 
-      assert winner_again.version.post.slug == "newer-collider"
+      assert winner_again.version.post.slug == "older-collider"
 
       # And the renamed slug now resolves to the loser (still published).
       assert renamed =
                DBStorage.find_by_url_slug(group["slug"], "en-US", "duplicate-slug-2")
 
-      assert renamed.version.post.slug == "older-collider"
+      assert renamed.version.post.slug == "newer-collider"
     end
 
     test "increments suffix when three posts collide on the same slug" do
-      # Three-way collision. Winner stays as-is; loser #1 becomes `-2`;
-      # loser #2 becomes `-3`. Auto-rename's `Enum.with_index(losers, 2)`
-      # produces the suffix sequence.
+      # Three-way collision. Incumbent (oldest) stays as-is; the newer two are
+      # renamed `-2`, `-3`. Auto-rename's `Enum.with_index(losers, 2)` produces
+      # the suffix sequence.
       {:ok, group} = Groups.add_group(unique_name(), mode: "slug")
 
-      [{p1, _, v1}, {p2, _, v2}, {p3, _, _v3}] =
+      [{p1, _, _v1}, {_p2, _, v2}, {_p3, _, v3}] =
         for slug <- ["first", "second", "third"] do
           {:ok, post} =
             Posts.create_post(group["slug"], %{title: "Slug #{slug}", slug: "post-#{slug}"})
@@ -335,18 +335,17 @@ defmodule PhoenixKit.Integration.Publishing.DBStorageUrlSlugLookupTest do
           {post, content, version}
         end
 
-      # `p3` is the newest (UUIDv7 monotonic) → wins.
+      # `p1` is the oldest (UUIDv7 monotonic) → the incumbent wins.
       winner = DBStorage.find_by_url_slug(group["slug"], "en-US", "triple-collide")
-      assert winner.version.post.uuid == p3.uuid
+      assert winner.version.post.uuid == p1.uuid
 
-      # The two older posts had their slugs renamed.
-      [renamed_c1] = DBStorage.list_contents(v1.uuid)
+      # The two NEWER posts had their slugs renamed.
       [renamed_c2] = DBStorage.list_contents(v2.uuid)
+      [renamed_c3] = DBStorage.list_contents(v3.uuid)
 
-      # Both got a suffix; the exact mapping (which got -2 vs -3) depends
-      # on `order_by p.inserted_at DESC` so `p2` (middle age) is `-2` and
-      # `p1` (oldest) is `-3`.
-      renamed_slugs = MapSet.new([renamed_c1.url_slug, renamed_c2.url_slug])
+      # Both got a suffix; with `order_by p.uuid ASC` the losers are `[p2, p3]`,
+      # so `p2` (second) is `-2` and `p3` (third) is `-3`.
+      renamed_slugs = MapSet.new([renamed_c2.url_slug, renamed_c3.url_slug])
       assert renamed_slugs == MapSet.new(["triple-collide-2", "triple-collide-3"])
 
       # Both renamed slugs are now reachable individually, and the
@@ -355,7 +354,7 @@ defmodule PhoenixKit.Integration.Publishing.DBStorageUrlSlugLookupTest do
       assert DBStorage.find_by_url_slug(group["slug"], "en-US", "triple-collide-3") != nil
 
       again = DBStorage.find_by_url_slug(group["slug"], "en-US", "triple-collide")
-      assert again.version.post.uuid == p3.uuid
+      assert again.version.post.uuid == p1.uuid
     end
   end
 

--- a/test/phoenix_kit_publishing/integration/groups_test.exs
+++ b/test/phoenix_kit_publishing/integration/groups_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixKit.Integration.Publishing.GroupsTest do
   use PhoenixKit.DataCase, async: true
 
   alias PhoenixKit.Modules.Publishing.Groups
+  alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.Posts
 
   defp unique_name, do: "Test Group #{System.unique_integer([:positive])}"
@@ -193,6 +194,20 @@ defmodule PhoenixKit.Integration.Publishing.GroupsTest do
       {:ok, updated} = Groups.update_group(group["slug"], %{slug: new_slug})
       assert updated["slug"] == new_slug
       assert {:error, :not_found} = Groups.get_group(group["slug"])
+    end
+
+    test "renaming the slug invalidates the old slug's listing cache (L6)" do
+      {:ok, group} = Groups.add_group(unique_name(), mode: "slug")
+      old_slug = group["slug"]
+
+      :ok = ListingCache.regenerate(old_slug)
+      assert ListingCache.exists?(old_slug)
+
+      {:ok, _} =
+        Groups.update_group(old_slug, %{slug: "renamed-#{System.unique_integer([:positive])}"})
+
+      # The old slug's cache entry must be dropped, not left dangling.
+      refute ListingCache.exists?(old_slug)
     end
 
     test "preserves unchanged fields on partial update" do

--- a/test/phoenix_kit_publishing/integration/posts_test.exs
+++ b/test/phoenix_kit_publishing/integration/posts_test.exs
@@ -1,6 +1,7 @@
 defmodule PhoenixKit.Integration.Publishing.PostsTest do
   use PhoenixKit.DataCase, async: true
 
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.Groups
   alias PhoenixKit.Modules.Publishing.Posts
   alias PhoenixKit.Modules.Publishing.Versions
@@ -331,6 +332,25 @@ defmodule PhoenixKit.Integration.Publishing.PostsTest do
       group = create_group("slug")
       {:ok, post} = Posts.create_post(group["slug"], %{title: "Trash Me"})
       assert {:ok, _uuid} = Posts.trash_post(group["slug"], post[:uuid])
+    end
+
+    test "timestamp_slot_taken? still sees a trashed post's slot (M2)" do
+      group = create_group("timestamp")
+      {:ok, post} = Posts.create_post(group["slug"], %{title: "Timed"})
+      db_post = DBStorage.get_post_by_uuid(post[:uuid])
+      date = db_post.post_date
+      time = db_post.post_time
+
+      assert DBStorage.timestamp_slot_taken?(group["slug"], date, time)
+
+      {:ok, _} = Posts.trash_post(group["slug"], post[:uuid])
+
+      # The unique index includes trashed rows, so the availability probe must
+      # too — otherwise a new post at the same minute would target the slot, the
+      # insert would hit the index, and the collision retry could never converge.
+      assert DBStorage.timestamp_slot_taken?(group["slug"], date, time)
+      # The live-serving lookup correctly treats the slot as free.
+      assert DBStorage.get_post_by_datetime(group["slug"], date, time) == nil
     end
 
     test "trashed post is excluded from list_posts" do

--- a/test/phoenix_kit_publishing/integration/posts_test.exs
+++ b/test/phoenix_kit_publishing/integration/posts_test.exs
@@ -216,6 +216,17 @@ defmodule PhoenixKit.Integration.Publishing.PostsTest do
       assert updated[:content] == "<p>New body</p>"
     end
 
+    test "read_post by UUID is pinned to the requested group (M6)" do
+      group_a = create_group("slug")
+      group_b = create_group("slug")
+      {:ok, post} = Posts.create_post(group_a["slug"], %{title: "In A"})
+
+      # The post resolves under its own group...
+      assert {:ok, _} = Posts.read_post(group_a["slug"], post[:uuid], nil)
+      # ...but NOT under another group's slug (cross-group UUID access).
+      assert {:error, :not_found} = Posts.read_post(group_b["slug"], post[:uuid], nil)
+    end
+
     test "returns updated post map" do
       group = create_group("slug")
       {:ok, post} = Posts.create_post(group["slug"], %{title: "Check Return"})

--- a/test/phoenix_kit_publishing/integration/posts_test.exs
+++ b/test/phoenix_kit_publishing/integration/posts_test.exs
@@ -5,6 +5,7 @@ defmodule PhoenixKit.Integration.Publishing.PostsTest do
   alias PhoenixKit.Modules.Publishing.Groups
   alias PhoenixKit.Modules.Publishing.Posts
   alias PhoenixKit.Modules.Publishing.Versions
+  alias PhoenixKit.Settings
 
   defp unique_name, do: "Posts Group #{System.unique_integer([:positive])}"
 
@@ -27,6 +28,24 @@ defmodule PhoenixKit.Integration.Publishing.PostsTest do
       assert post[:time]
       assert post[:version] == 1
       assert post[:mode] in ["timestamp", :timestamp]
+    end
+
+    test "stamps the timestamp in the configured site time zone (L5)" do
+      group = create_group("timestamp")
+
+      {:ok, _} = Settings.update_setting("time_zone", "0")
+      {:ok, utc_post} = Posts.create_post(group["slug"], %{})
+
+      {:ok, _} = Settings.update_setting("time_zone", "5")
+      {:ok, plus5_post} = Posts.create_post(group["slug"], %{})
+
+      utc_dt = NaiveDateTime.new!(utc_post[:date], utc_post[:time])
+      plus5_dt = NaiveDateTime.new!(plus5_post[:date], plus5_post[:time])
+
+      # The +5 post is stamped ~5h ahead of the UTC one (both created seconds
+      # apart), so creation now matches the editor's naive wall clock + display.
+      diff_minutes = NaiveDateTime.diff(plus5_dt, utc_dt, :second) / 60
+      assert_in_delta diff_minutes, 300, 1.5
     end
 
     test "creates post with title" do

--- a/test/phoenix_kit_publishing/integration/posts_test.exs
+++ b/test/phoenix_kit_publishing/integration/posts_test.exs
@@ -226,6 +226,32 @@ defmodule PhoenixKit.Integration.Publishing.PostsTest do
       assert updated[:version]
       assert updated[:metadata]
     end
+
+    test "records the old url_slug for 301 redirects when the slug changes (H2)" do
+      group = create_group("slug")
+      {:ok, post} = Posts.create_post(group["slug"], %{title: "Reslug Me"})
+
+      # nil -> first-slug: nothing to record yet (no prior custom slug).
+      {:ok, v1} = Posts.update_post(group["slug"], post, %{"url_slug" => "first-slug"}, %{})
+      refute "first-slug" in (v1[:metadata][:previous_url_slugs] || [])
+
+      # first-slug -> second-slug: the old slug must be recorded for the 301.
+      {:ok, v2} = Posts.update_post(group["slug"], v1, %{"url_slug" => "second-slug"}, %{})
+      assert "first-slug" in (v2[:metadata][:previous_url_slugs] || [])
+
+      # Publish so the active-version-only 301 lookup can resolve the stale slug.
+      :ok = Versions.publish_version(group["slug"], post[:uuid], 1)
+
+      assert {:ok, found} =
+               Posts.find_by_previous_url_slug(group["slug"], v2[:language], "first-slug")
+
+      assert found.slug == post[:slug]
+
+      # Reverting to first-slug drops it from history so it can't 301 to itself.
+      {:ok, v3} = Posts.update_post(group["slug"], v2, %{"url_slug" => "first-slug"}, %{})
+      refute "first-slug" in (v3[:metadata][:previous_url_slugs] || [])
+      assert "second-slug" in (v3[:metadata][:previous_url_slugs] || [])
+    end
   end
 
   # ============================================================================

--- a/test/phoenix_kit_publishing/integration/posts_test.exs
+++ b/test/phoenix_kit_publishing/integration/posts_test.exs
@@ -216,6 +216,20 @@ defmodule PhoenixKit.Integration.Publishing.PostsTest do
       assert updated[:content] == "<p>New body</p>"
     end
 
+    test "update_post does not publish a version by itself — that's publish_version's job (M4)" do
+      group = create_group("slug")
+      {:ok, post} = Posts.create_post(group["slug"], %{title: "Defer", content: "x"})
+
+      # Saving with status=published must NOT mark the version published on its
+      # own; publishing is atomic via Versions.publish_version. Otherwise a save
+      # could commit published while the paired publish rolled back.
+      {:ok, _} = Posts.update_post(group["slug"], post, %{"status" => "published"}, %{})
+
+      [v] = DBStorage.list_versions(post[:uuid])
+      assert v.status == "draft"
+      assert DBStorage.get_post_by_uuid(post[:uuid]).active_version_uuid == nil
+    end
+
     test "read_post by UUID is pinned to the requested group (M6)" do
       group_a = create_group("slug")
       group_b = create_group("slug")

--- a/test/phoenix_kit_publishing/integration/stale_fixer_test.exs
+++ b/test/phoenix_kit_publishing/integration/stale_fixer_test.exs
@@ -9,8 +9,17 @@ defmodule PhoenixKit.Integration.Publishing.StaleFixerTest do
   alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.Groups
   alias PhoenixKit.Modules.Publishing.Posts
+  alias PhoenixKit.Modules.Publishing.PublishingPost
   alias PhoenixKit.Modules.Publishing.StaleFixer
   alias PhoenixKit.Settings
+
+  # Backdate a post past the empty-post grace period so the stale fixer acts on it.
+  defp age_post(uuid, seconds_ago) do
+    past = DateTime.add(DateTime.utc_now(), -seconds_ago, :second) |> DateTime.truncate(:second)
+
+    from(p in PublishingPost, where: p.uuid == ^uuid)
+    |> Repo.update_all(set: [inserted_at: past])
+  end
 
   defp unique_name, do: "stale-fixer-group-#{System.unique_integer([:positive])}"
 
@@ -205,5 +214,34 @@ defmodule PhoenixKit.Integration.Publishing.StaleFixerTest do
 
     [healed] = DBStorage.list_versions(post.uuid)
     assert healed.status == "draft"
+  end
+
+  test "trashes (not hard-deletes) an empty post past the grace period (M9)" do
+    {:ok, group} = Groups.add_group(unique_name(), mode: "timestamp")
+    {:ok, post} = Posts.create_post(group["slug"], %{})
+    age_post(post.uuid, 600)
+
+    db_post = DBStorage.get_post_by_uuid(post.uuid, [:group])
+    StaleFixer.fix_stale_post(db_post)
+
+    reloaded = DBStorage.get_post_by_uuid(post.uuid)
+    # Soft-deleted (recoverable), not hard-deleted.
+    assert reloaded
+    refute is_nil(reloaded.trashed_at)
+  end
+
+  test "does NOT trash a version that has only a featured image (M9)" do
+    {:ok, group} = Groups.add_group(unique_name(), mode: "timestamp")
+    {:ok, post} = Posts.create_post(group["slug"], %{})
+    [v1] = DBStorage.list_versions(post.uuid)
+    {:ok, _} = DBStorage.update_version(v1, %{data: %{"featured_image_uuid" => "img-123"}})
+    age_post(post.uuid, 600)
+
+    db_post = DBStorage.get_post_by_uuid(post.uuid, [:group])
+    StaleFixer.fix_stale_post(db_post)
+
+    reloaded = DBStorage.get_post_by_uuid(post.uuid)
+    # A featured-image-only version is content — must not be auto-trashed.
+    assert is_nil(reloaded.trashed_at)
   end
 end

--- a/test/phoenix_kit_publishing/integration/stale_fixer_test.exs
+++ b/test/phoenix_kit_publishing/integration/stale_fixer_test.exs
@@ -186,4 +186,24 @@ defmodule PhoenixKit.Integration.Publishing.StaleFixerTest do
     [version] = DBStorage.list_versions(post.uuid)
     assert Enum.map(DBStorage.list_contents(version.uuid), & &1.language) == ["en-US"]
   end
+
+  test "demotes a published version that has no active version back to draft (M4 heal)" do
+    {:ok, _} = Settings.update_setting("content_language", "en-US")
+    {:ok, group} = Groups.add_group(unique_name(), mode: "slug")
+    {:ok, post} = Posts.create_post(group["slug"], %{title: "Orphan Published", content: "body"})
+
+    [v1] = DBStorage.list_versions(post.uuid)
+
+    # Simulate the M4 inconsistency: the version is marked published, but the post
+    # was never activated (the publish transaction rolled back after the status
+    # write under the old non-atomic flow).
+    {:ok, _} = DBStorage.update_version(v1, %{status: "published"})
+    db_post = DBStorage.get_post_by_uuid(post.uuid, [:group])
+    assert db_post.active_version_uuid == nil
+
+    StaleFixer.fix_stale_post(db_post)
+
+    [healed] = DBStorage.list_versions(post.uuid)
+    assert healed.status == "draft"
+  end
 end

--- a/test/phoenix_kit_publishing/integration/translation_manager_test.exs
+++ b/test/phoenix_kit_publishing/integration/translation_manager_test.exs
@@ -128,6 +128,7 @@ defmodule PhoenixKit.Integration.Publishing.TranslationManagerTest do
                  group["slug"],
                  post[:uuid],
                  "de-DE",
+                 nil,
                  actor_uuid: @actor_uuid
                )
 
@@ -164,6 +165,29 @@ defmodule PhoenixKit.Integration.Publishing.TranslationManagerTest do
         actor_uuid: nil,
         metadata_has: %{"language" => "de-DE"}
       )
+    end
+
+    test "clears the GIVEN version, not the latest (data-loss regression)",
+         %{group: group, post: post} do
+      # v1: en-US + de-DE.
+      assert {:ok, _} =
+               TranslationManager.add_language_to_post(group["slug"], post[:uuid], "de-DE")
+
+      # v2 (now the latest): cloned from v1, so it carries de-DE too.
+      assert {:ok, _v2} = DBStorage.create_version_from(post[:uuid], 1)
+
+      [v1, v2] = DBStorage.list_versions(post[:uuid]) |> Enum.sort_by(& &1.version_number)
+      assert {v1.version_number, v2.version_number} == {1, 2}
+      assert Enum.any?(DBStorage.list_contents(v1.uuid), &(&1.language == "de-DE"))
+      assert Enum.any?(DBStorage.list_contents(v2.uuid), &(&1.language == "de-DE"))
+
+      # Clear de-DE on v1 (the OLDER, non-latest version) explicitly.
+      assert :ok = TranslationManager.clear_translation(group["slug"], post[:uuid], "de-DE", 1)
+
+      # v1's de-DE is gone; v2 (latest) is untouched. Before the fix this
+      # resolved `nil` -> latest version and would have deleted v2's row.
+      refute Enum.any?(DBStorage.list_contents(v1.uuid), &(&1.language == "de-DE"))
+      assert Enum.any?(DBStorage.list_contents(v2.uuid), &(&1.language == "de-DE"))
     end
   end
 

--- a/test/phoenix_kit_publishing/listing_cache/lock_table_owner_test.exs
+++ b/test/phoenix_kit_publishing/listing_cache/lock_table_owner_test.exs
@@ -7,6 +7,7 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache.LockTableOwnerTest do
 
   use ExUnit.Case, async: false
 
+  alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.ListingCache.LockTableOwner
 
   @lock_table :phoenix_kit_listing_cache_locks
@@ -29,7 +30,7 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache.LockTableOwnerTest do
     # Pins the contract do_regenerate_with_lock/2's release relies on: the lock
     # value is {timestamp, token}, and a release matched on a stale token is a
     # no-op — so a slow original holder can't delete a takeover holder's lock.
-    PhoenixKit.Modules.Publishing.ListingCache.ensure_lock_table_exists()
+    ListingCache.ensure_lock_table_exists()
     group = "l10-#{System.unique_integer([:positive])}"
     token_a = make_ref()
     token_b = make_ref()

--- a/test/phoenix_kit_publishing/listing_cache/lock_table_owner_test.exs
+++ b/test/phoenix_kit_publishing/listing_cache/lock_table_owner_test.exs
@@ -1,0 +1,27 @@
+defmodule PhoenixKit.Modules.Publishing.ListingCache.LockTableOwnerTest do
+  @moduledoc """
+  Regression test for M8 — the regeneration-lock ETS table must be owned by a
+  long-lived process, not whichever transient request first creates it. Otherwise
+  the table dies with that process and the lock ops 500 a public read.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Modules.Publishing.ListingCache.LockTableOwner
+
+  @lock_table :phoenix_kit_listing_cache_locks
+
+  test "starting the owner makes the lock table exist, owned by a live process" do
+    {:ok, pid} =
+      LockTableOwner.start_link(name: :"lock_owner_#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    assert :ets.whereis(@lock_table) != :undefined
+
+    # The table must be owned by a LIVE process — the bug was a transient request
+    # process owning it and dying, leaving a dangling named table.
+    owner = :ets.info(@lock_table, :owner)
+    assert is_pid(owner) and Process.alive?(owner)
+  end
+end

--- a/test/phoenix_kit_publishing/listing_cache/lock_table_owner_test.exs
+++ b/test/phoenix_kit_publishing/listing_cache/lock_table_owner_test.exs
@@ -24,4 +24,25 @@ defmodule PhoenixKit.Modules.Publishing.ListingCache.LockTableOwnerTest do
     owner = :ets.info(@lock_table, :owner)
     assert is_pid(owner) and Process.alive?(owner)
   end
+
+  test "a superseded holder's token-scoped release leaves a takeover lock intact (L10)" do
+    # Pins the contract do_regenerate_with_lock/2's release relies on: the lock
+    # value is {timestamp, token}, and a release matched on a stale token is a
+    # no-op — so a slow original holder can't delete a takeover holder's lock.
+    PhoenixKit.Modules.Publishing.ListingCache.ensure_lock_table_exists()
+    group = "l10-#{System.unique_integer([:positive])}"
+    token_a = make_ref()
+    token_b = make_ref()
+
+    # B took over with a fresh token after A went stale.
+    :ets.insert(@lock_table, {group, {1, token_b}})
+
+    # A's release (token_a) must delete nothing and leave B's lock untouched.
+    assert :ets.select_delete(@lock_table, [{{group, {:_, token_a}}, [], [true]}]) == 0
+    assert :ets.lookup(@lock_table, group) == [{group, {1, token_b}}]
+
+    # B's own release cleanly removes its lock.
+    assert :ets.select_delete(@lock_table, [{{group, {:_, token_b}}, [], [true]}]) == 1
+    assert :ets.lookup(@lock_table, group) == []
+  end
 end

--- a/test/phoenix_kit_publishing/listing_cache_test.exs
+++ b/test/phoenix_kit_publishing/listing_cache_test.exs
@@ -30,17 +30,10 @@ defmodule PhoenixKit.Modules.Publishing.ListingCacheTest do
     end
   end
 
-  describe "loaded_at_key/1" do
+  describe "cache_generated_at_key/1" do
     test "returns a tuple distinct from persistent_term_key" do
       group = unique_group()
-      refute ListingCache.loaded_at_key(group) == ListingCache.persistent_term_key(group)
-    end
-  end
-
-  describe "cache_generated_at_key/1" do
-    test "returns a tuple distinct from loaded_at_key" do
-      group = unique_group()
-      refute ListingCache.cache_generated_at_key(group) == ListingCache.loaded_at_key(group)
+      refute ListingCache.cache_generated_at_key(group) == ListingCache.persistent_term_key(group)
     end
   end
 
@@ -53,7 +46,7 @@ defmodule PhoenixKit.Modules.Publishing.ListingCacheTest do
 
     test "return the value from persistent_term when set" do
       group = unique_group()
-      :persistent_term.put(ListingCache.loaded_at_key(group), "2026-04-27T00:00:00Z")
+      # Both readers share one entry now (L12) — memory_loaded_at == cache_generated_at.
       :persistent_term.put(ListingCache.cache_generated_at_key(group), "2026-04-27T00:00:00Z")
 
       assert ListingCache.memory_loaded_at(group) == "2026-04-27T00:00:00Z"
@@ -230,6 +223,19 @@ defmodule PhoenixKit.Modules.Publishing.ListingCacheRegenerateTest do
 
       :ok = ListingCache.invalidate(group_slug)
       refute ListingCache.exists?(group_slug)
+    end
+
+    test "erase_all/0 clears the cache so a re-enable can't serve stale data (L7)",
+         %{group_slug: group_slug} do
+      :ok = ListingCache.regenerate(group_slug)
+      assert ListingCache.exists?(group_slug)
+      assert is_binary(ListingCache.cache_generated_at(group_slug))
+
+      :ok = ListingCache.erase_all()
+
+      refute ListingCache.exists?(group_slug)
+      # The timestamp prefixes are cleared too (the old per-group loop missed them).
+      assert ListingCache.cache_generated_at(group_slug) == nil
     end
   end
 

--- a/test/phoenix_kit_publishing/listing_cache_test.exs
+++ b/test/phoenix_kit_publishing/listing_cache_test.exs
@@ -171,10 +171,13 @@ defmodule PhoenixKit.Modules.Publishing.ListingCacheRegenerateTest do
 
   use PhoenixKitPublishing.DataCase, async: false
 
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.Groups
   alias PhoenixKit.Modules.Publishing.ListingCache
   alias PhoenixKit.Modules.Publishing.Posts
   alias PhoenixKit.Modules.Publishing.Versions
+  alias PhoenixKit.Modules.Publishing.Web.Controller.Listing
+  alias PhoenixKit.Modules.Publishing.Web.Controller.PostFetching
   alias PhoenixKit.Settings
 
   setup do
@@ -256,6 +259,35 @@ defmodule PhoenixKit.Modules.Publishing.ListingCacheRegenerateTest do
       :ok = ListingCache.invalidate(group_slug)
       result = ListingCache.load_into_memory(group_slug)
       assert result in [:ok] or match?({:error, _}, result)
+    end
+  end
+
+  describe "public cache-miss fallback uses the active/published listing source" do
+    test "a published post with a newer DRAFT version stays published on a cache miss",
+         %{group_slug: group_slug} do
+      # Regression: on a cache miss the public listing fell back to list_posts/2
+      # (LATEST version), so a published post whose latest version is an
+      # unpublished draft would surface with draft status — dropped by
+      # filter_published — and vanish from the public listing during cold-start
+      # or concurrent regeneration. The fallback now mirrors the cache source
+      # (list_posts_for_listing/1 — the ACTIVE/published version).
+      {:ok, _} = Settings.update_boolean_setting("publishing_memory_cache_enabled", false)
+
+      {:ok, post} =
+        Posts.create_post(group_slug, %{title: "Live", slug: "live", content: "Published body"})
+
+      :ok = Versions.publish_version(group_slug, post.uuid, 1)
+      # v2 becomes the LATEST version and is an unpublished draft.
+      {:ok, _v2} = DBStorage.create_version_from(post.uuid, 1)
+
+      posts = PostFetching.fetch_posts_with_cache(group_slug)
+      published = Listing.filter_published(posts)
+
+      # The post is still listed (active version is published)...
+      assert Enum.any?(published, &(&1.slug == post.slug))
+      # ...and surfaces with published status, not the latest draft's.
+      listed = Enum.find(posts, &(&1.slug == post.slug))
+      assert listed.metadata.status == "published"
     end
   end
 end

--- a/test/phoenix_kit_publishing/mapper_test.exs
+++ b/test/phoenix_kit_publishing/mapper_test.exs
@@ -358,6 +358,26 @@ defmodule PhoenixKit.Modules.Publishing.DBStorage.MapperTest do
       assert result.content == nil
     end
 
+    test "listing metadata carries allow_version_access (public version dropdown)" do
+      group = build_group()
+      post = build_post(group)
+
+      # Regression: the cached listing map dropped this field, so the public
+      # version dropdown only appeared on a cache miss. It must mirror the full
+      # post map and reflect the version's setting.
+      on_version = build_version(post, %{data: %{"allow_version_access" => true}})
+      off_version = build_version(post, %{data: %{}})
+
+      on_result =
+        Mapper.to_listing_map(post, on_version, [build_content(on_version)], [on_version])
+
+      off_result =
+        Mapper.to_listing_map(post, off_version, [build_content(off_version)], [off_version])
+
+      assert on_result.metadata.allow_version_access == true
+      assert off_result.metadata.allow_version_access == false
+    end
+
     test "falls back to first content when site default language not found" do
       group = build_group()
       post = build_post(group)

--- a/test/phoenix_kit_publishing/metadata_test.exs
+++ b/test/phoenix_kit_publishing/metadata_test.exs
@@ -38,9 +38,9 @@ defmodule PhoenixKit.Modules.Publishing.MetadataTest do
 
     test "ignores content inside components" do
       content = """
-      <Hero title="Welcome">
+      <CTA title="Welcome">
         # This should be ignored
-      </Hero>
+      </CTA>
 
       # Real Title
       """
@@ -51,11 +51,6 @@ defmodule PhoenixKit.Modules.Publishing.MetadataTest do
     test "extracts title from Headline component" do
       content = "<Headline>My Headline</Headline>"
       assert Metadata.extract_title_from_content(content) == "My Headline"
-    end
-
-    test "extracts title from Hero component title attribute" do
-      content = ~s(<Hero title="Welcome Home" background="dark" />)
-      assert Metadata.extract_title_from_content(content) == "Welcome Home"
     end
   end
 end

--- a/test/phoenix_kit_publishing/page_builder/parser_test.exs
+++ b/test/phoenix_kit_publishing/page_builder/parser_test.exs
@@ -10,11 +10,11 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.ParserTest do
 
   describe "parse/1 — element nodes" do
     test "parses a self-closed element with only attributes" do
-      assert {:ok, ast} = Parser.parse(~s(<Hero variant="split-image"/>))
+      assert {:ok, ast} = Parser.parse(~s(<Video variant="autoplay"/>))
 
       assert ast == %{
-               type: :hero,
-               attributes: %{"variant" => "split-image"},
+               type: :video,
+               attributes: %{"variant" => "autoplay"},
                children: [],
                content: nil
              }
@@ -31,10 +31,10 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.ParserTest do
     end
 
     test "parses an element with children into the children key" do
-      input = ~s(<Page><Headline>Hi</Headline><CTA action="/x">Go</CTA></Page>)
+      input = ~s(<EntityForm><Headline>Hi</Headline><CTA action="/x">Go</CTA></EntityForm>)
       assert {:ok, ast} = Parser.parse(input)
 
-      assert ast.type == :page
+      assert ast.type == :entityform
       assert length(ast.children) == 2
       assert Enum.at(ast.children, 0).type == :headline
       assert Enum.at(ast.children, 0).content == "Hi"
@@ -43,20 +43,20 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.ParserTest do
     end
 
     test "downcases tag names to atoms" do
-      assert {:ok, %{type: :hero}} = Parser.parse("<Hero/>")
-      assert {:ok, %{type: :hero}} = Parser.parse("<hero/>")
-      assert {:ok, %{type: :hero}} = Parser.parse("<HERO/>")
+      assert {:ok, %{type: :video}} = Parser.parse("<Video/>")
+      assert {:ok, %{type: :video}} = Parser.parse("<video/>")
+      assert {:ok, %{type: :video}} = Parser.parse("<VIDEO/>")
     end
 
     test "downcases attribute keys" do
-      assert {:ok, ast} = Parser.parse(~s(<Hero VARIANT="split-image"/>))
-      assert ast.attributes["variant"] == "split-image"
+      assert {:ok, ast} = Parser.parse(~s(<Video VARIANT="autoplay"/>))
+      assert ast.attributes["variant"] == "autoplay"
     end
   end
 
   describe "parse/1 — error paths" do
     test "returns parse_error tuple for malformed XML" do
-      assert {:error, {:parse_error, _}} = Parser.parse("<Hero")
+      assert {:error, {:parse_error, _}} = Parser.parse("<Video")
     end
 
     test "returns invalid_content for non-binary input" do
@@ -66,7 +66,7 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.ParserTest do
     end
 
     test "trims content before parsing" do
-      assert {:ok, %{type: :hero}} = Parser.parse("   \n  <Hero/>  \n")
+      assert {:ok, %{type: :video}} = Parser.parse("   \n  <Video/>  \n")
     end
   end
 

--- a/test/phoenix_kit_publishing/page_builder/renderer_test.exs
+++ b/test/phoenix_kit_publishing/page_builder/renderer_test.exs
@@ -67,24 +67,11 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilder.RendererTest do
   end
 
   describe "render/2 — known component types resolve correctly" do
-    test "resolves :page component type to a known module" do
-      ast = %{
-        type: :page,
-        attributes: %{},
-        children: [
-          %{type: :unknown, attributes: %{}, content: "child"}
-        ]
-      }
-
-      result = Renderer.render(ast, %{})
-      # Either {:ok, html} for known component or {:error, ...}
-      assert match?({:ok, _}, result) or match?({:error, _}, result)
-    end
-
-    test "resolves :hero component type" do
-      ast = %{type: :hero, attributes: %{}, children: []}
-      result = Renderer.render(ast, %{})
-      assert match?({:ok, _}, result) or match?({:error, _}, result)
+    test "a removed component type (Page/Hero) no longer resolves" do
+      # Page/Hero were removed with the Pages module (core 0fc3de09); their type
+      # now falls through to the catch-all instead of a real module.
+      result = Renderer.render(%{type: :page, attributes: %{}, children: []}, %{})
+      assert match?({:error, _}, result) or match?({:ok, _}, result)
     end
 
     test "resolves :headline component type" do

--- a/test/phoenix_kit_publishing/page_builder_test.exs
+++ b/test/phoenix_kit_publishing/page_builder_test.exs
@@ -45,9 +45,11 @@ defmodule PhoenixKit.Modules.Publishing.PageBuilderTest do
       assert html(safe) =~ "Hi Ada"
     end
 
-    test "missing variables resolve to empty string" do
+    test "an unresolved variable is left as a literal placeholder, not deleted (L9)" do
+      # Replacing it with "" would silently delete author-written braces when
+      # content is rendered without the data that fills them.
       assert {:ok, safe} = PageBuilder.render_content("<Foobar>Hi {{missing}}</Foobar>")
-      assert html(safe) =~ "Hi "
+      assert html(safe) =~ "{{missing}}"
     end
 
     test "returns parse_error for malformed XML" do

--- a/test/phoenix_kit_publishing/renderer_test.exs
+++ b/test/phoenix_kit_publishing/renderer_test.exs
@@ -563,5 +563,41 @@ defmodule PhoenixKit.Modules.Publishing.RendererTest do
       # file is absent in test) — NOT left as escaped literal text.
       refute html =~ "&lt;Image"
     end
+
+    test "a multi-line <Image> tag is detected as a component (M11)" do
+      # The format spec puts attributes on the next line. With the old
+      # `<Image ` (trailing-space) detection this routed to the plain path and
+      # smartypants curled the quotes inside the tag, breaking it.
+      html =
+        Renderer.render_markdown(
+          ~s|Before\n\n<Image\n  file_uuid="#{@uuid}"\n  alt="x"/>\n\nAfter|
+        )
+
+      refute html =~ "&lt;Image"
+      # No curly quotes — the tag wasn't fed through smartypants as prose.
+      refute html =~ "“"
+      refute html =~ "”"
+    end
+  end
+
+  describe "render_markdown/1 — code-region integrity" do
+    test "does not corrupt indentation or blank lines inside a fenced code block (M10)" do
+      md = "```\n    ## indented sample\n\n\n\n    more code\n```"
+      html = Renderer.render_markdown(md)
+
+      # The blank-line spacer must not fire inside the fence...
+      refute html =~ "&nbsp;"
+      # ...and the heading-indent strip must leave the indentation intact.
+      assert html =~ "    ## indented sample"
+    end
+
+    test "escapes raw HTML in a fenced block on the plain path too (M12)" do
+      # No PHK components here, so this takes the pure-Earmark path. With
+      # escape: false a raw <script> in a fence would otherwise render live.
+      html = Renderer.render_markdown("Example:\n\n```\n<script>alert(1)</script>\n```\n")
+
+      assert html =~ "&lt;script&gt;"
+      refute html =~ "<script>"
+    end
   end
 end

--- a/test/phoenix_kit_publishing/renderer_test.exs
+++ b/test/phoenix_kit_publishing/renderer_test.exs
@@ -538,6 +538,16 @@ defmodule PhoenixKit.Modules.Publishing.RendererTest do
       refute html =~ "<img"
     end
 
+    test "a component in a ~~~ tilde-fenced code block renders as visible code" do
+      html =
+        Renderer.render_markdown(
+          ~s|Example:\n\n~~~\n<Image file_uuid="#{@uuid}" alt="x"/>\n~~~\n|
+        )
+
+      assert html =~ "&lt;Image"
+      refute html =~ "<img"
+    end
+
     test "a component in inline code renders as visible code, not a live component" do
       html = Renderer.render_markdown("Use `<Image file_uuid=\"#{@uuid}\"/>` to embed.")
 

--- a/test/phoenix_kit_publishing/renderer_test.exs
+++ b/test/phoenix_kit_publishing/renderer_test.exs
@@ -555,6 +555,13 @@ defmodule PhoenixKit.Modules.Publishing.RendererTest do
       refute html =~ "<img"
     end
 
+    test "a component in double-backtick inline code renders as visible code (L8)" do
+      html = Renderer.render_markdown("Use ``<Image file_uuid=\"#{@uuid}\"/>`` to embed.")
+
+      assert html =~ "&lt;Image"
+      refute html =~ "<img"
+    end
+
     test "a component OUTSIDE code blocks still renders as a component" do
       html =
         Renderer.render_markdown(~s|Before\n\n<Image file_uuid="#{@uuid}" alt="x"/>\n\nAfter|)

--- a/test/phoenix_kit_publishing/renderer_test.exs
+++ b/test/phoenix_kit_publishing/renderer_test.exs
@@ -522,4 +522,36 @@ defmodule PhoenixKit.Modules.Publishing.RendererTest do
       assert html =~ "/proxy?next=/file/"
     end
   end
+
+  describe "render_markdown/1 — PHK components inside code blocks" do
+    @uuid "018e3c4a-9f6b-7890-abcd-ef1234567890"
+
+    test "a component in a fenced code block renders as visible code, not a live component" do
+      html =
+        Renderer.render_markdown(
+          ~s|Example:\n\n```\n<Image file_uuid="#{@uuid}" alt="x"/>\n```\n|
+        )
+
+      # The literal tag is shown as escaped text inside the code block...
+      assert html =~ "&lt;Image"
+      # ...and was NOT turned into a real image.
+      refute html =~ "<img"
+    end
+
+    test "a component in inline code renders as visible code, not a live component" do
+      html = Renderer.render_markdown("Use `<Image file_uuid=\"#{@uuid}\"/>` to embed.")
+
+      assert html =~ "&lt;Image"
+      refute html =~ "<img"
+    end
+
+    test "a component OUTSIDE code blocks still renders as a component" do
+      html =
+        Renderer.render_markdown(~s|Before\n\n<Image file_uuid="#{@uuid}" alt="x"/>\n\nAfter|)
+
+      # Resolved to a real <img> (or the "Image not available" fallback when the
+      # file is absent in test) — NOT left as escaped literal text.
+      refute html =~ "&lt;Image"
+    end
+  end
 end

--- a/test/phoenix_kit_publishing/router_dispatch_test.exs
+++ b/test/phoenix_kit_publishing/router_dispatch_test.exs
@@ -258,23 +258,52 @@ defmodule PhoenixKitPublishing.RouterDispatchIntegrationTest do
              ]
     end
 
-    test "checks path_info[1] only after path_info[0] doesn't match (branch sequencing)" do
-      # Pin the cond ordering — guards against a future refactor that flips
-      # the checks and makes a host route shaped `/group-name/<literal>` get
-      # treated as `language=group-name, group=<literal>` instead of
-      # `group=group-name, path=[<literal>]`.
+    test "does NOT hijack a host route whose 2nd segment matches a group (H3)" do
+      # `/not-a-group/<group>/post` is NOT a localized publishing URL — segment 0
+      # isn't a language the site serves — so the localized branch must not fire.
+      # Otherwise any host route `/<word>/<group-named-seg>` (e.g. /company/news)
+      # would be diverted into publishing under language=<word>.
       {:ok, real_group} = Groups.add_group(unique_name())
       refute_group_named("not-a-group")
 
       conn = %Plug.Conn{
+        method: "GET",
         path_info: ["not-a-group", real_group["slug"], "post"],
         request_path: "/not-a-group/" <> real_group["slug"] <> "/post",
         private: %{}
       }
 
-      # path_info[0]="not-a-group" must fail known_group?/1 first, then
-      # path_info[1]=real slug succeeds and triggers rewrite.
-      assert {:rewrite, _rewritten} = RouterDispatch.maybe_rewrite(conn)
+      assert RouterDispatch.maybe_rewrite(conn) == :pass
+    end
+
+    test "does NOT hijack when segment 0 is a 3-letter non-language (api/faq) (H3)" do
+      # `looks_like_language_code?/1` accepts any 2–3 letter token, so a strict
+      # enabled-language check is required — else `/api/<group>` serves a 200.
+      {:ok, real_group} = Groups.add_group(unique_name())
+
+      conn = %Plug.Conn{
+        method: "GET",
+        path_info: ["api", real_group["slug"]],
+        request_path: "/api/" <> real_group["slug"],
+        private: %{}
+      }
+
+      assert RouterDispatch.maybe_rewrite(conn) == :pass
+    end
+
+    test "passes through a non-GET request even when a segment is a group (H3)" do
+      # Public publishing is read-only; a host `POST /<group>/...` must not be
+      # diverted into the GET-only internal scope.
+      {:ok, real_group} = Groups.add_group(unique_name())
+
+      conn = %Plug.Conn{
+        method: "POST",
+        path_info: [real_group["slug"], "submit"],
+        request_path: "/" <> real_group["slug"] <> "/submit",
+        private: %{}
+      }
+
+      assert RouterDispatch.maybe_rewrite(conn) == :pass
     end
   end
 

--- a/test/phoenix_kit_publishing/schema_test.exs
+++ b/test/phoenix_kit_publishing/schema_test.exs
@@ -232,7 +232,6 @@ defmodule PhoenixKit.Modules.Publishing.SchemaTest do
       assert PublishingVersion.get_allow_version_access(version) == false
       assert PublishingVersion.get_featured_image_uuid(version) == nil
       assert PublishingVersion.get_tags(version) == []
-      assert PublishingVersion.get_seo(version) == %{}
       assert PublishingVersion.get_description(version) == nil
     end
 
@@ -242,7 +241,6 @@ defmodule PhoenixKit.Modules.Publishing.SchemaTest do
           "allow_version_access" => true,
           "featured_image_uuid" => "img-uuid-123",
           "tags" => ["elixir", "phoenix"],
-          "seo" => %{"og_title" => "My Post"},
           "description" => "A test description"
         }
       }
@@ -250,7 +248,6 @@ defmodule PhoenixKit.Modules.Publishing.SchemaTest do
       assert PublishingVersion.get_allow_version_access(version) == true
       assert PublishingVersion.get_featured_image_uuid(version) == "img-uuid-123"
       assert PublishingVersion.get_tags(version) == ["elixir", "phoenix"]
-      assert PublishingVersion.get_seo(version) == %{"og_title" => "My Post"}
       assert PublishingVersion.get_description(version) == "A test description"
     end
   end

--- a/test/phoenix_kit_publishing/slug_helpers_test.exs
+++ b/test/phoenix_kit_publishing/slug_helpers_test.exs
@@ -194,6 +194,18 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpersDBTest do
                SlugHelpers.validate_url_slug(group_slug, "fresh-slug", "en-US")
     end
 
+    test "rejects claiming another post's previous slug (M13)", %{group_slug: group_slug} do
+      {:ok, post} = Posts.create_post(group_slug, %{title: "Mover", slug: "mover"})
+      {:ok, v1} = Posts.update_post(group_slug, post, %{"url_slug" => "old-address"}, %{})
+      :ok = Versions.publish_version(group_slug, post[:uuid], 1)
+      # old-address -> new-address records "old-address" as the post's previous slug.
+      {:ok, _v2} = Posts.update_post(group_slug, v1, %{"url_slug" => "new-address"}, %{})
+
+      # A different post may NOT claim "old-address" — it would hijack the 301.
+      assert {:error, :conflicts_with_previous_slug} =
+               SlugHelpers.validate_url_slug(group_slug, "old-address", "en-US", "another-post")
+    end
+
     test "exclude_post_slug allows a post to keep its own URL", %{group_slug: group_slug} do
       {:ok, post} = Posts.create_post(group_slug, %{title: "Own URL", slug: "own-url"})
 

--- a/test/phoenix_kit_publishing/slug_helpers_test.exs
+++ b/test/phoenix_kit_publishing/slug_helpers_test.exs
@@ -133,9 +133,11 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpersDBTest do
 
   use PhoenixKitPublishing.DataCase, async: false
 
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.Groups
   alias PhoenixKit.Modules.Publishing.Posts
   alias PhoenixKit.Modules.Publishing.SlugHelpers
+  alias PhoenixKit.Modules.Publishing.Versions
   alias PhoenixKit.Settings
 
   setup do
@@ -254,6 +256,29 @@ defmodule PhoenixKit.Modules.Publishing.SlugHelpersDBTest do
   describe "clear_conflicting_url_slugs/2" do
     test "returns [] when no conflicts exist", %{group_slug: group_slug} do
       assert SlugHelpers.clear_conflicting_url_slugs(group_slug, "no-conflicts") == []
+    end
+
+    test "with the memory cache disabled, finds + clears conflicts via the DB fallback",
+         %{group_slug: group_slug} do
+      # Regression: this is a mutation path. On a cache miss (memory cache
+      # disabled, or a loser of a concurrent regeneration) it must fall back to
+      # a DB listing — not silently return [] and skip clearing a stale custom
+      # url_slug that now collides with another post's slug.
+      {:ok, _} = Settings.update_boolean_setting("publishing_memory_cache_enabled", false)
+
+      # Post B owns the custom url_slug "taken-slug" on en-US.
+      {:ok, post_b} = Posts.create_post(group_slug, %{title: "Post B", slug: "post-b"})
+      [version] = DBStorage.list_versions(post_b.uuid)
+      [content] = DBStorage.list_contents(version.uuid)
+      {:ok, _} = DBStorage.update_content(content, %{url_slug: "taken-slug"})
+      :ok = Versions.publish_version(group_slug, post_b.uuid, version.version_number)
+
+      # Clearing conflicts for "taken-slug" must surface post B's clash, not [].
+      assert [{"post-b", "en-US"}] =
+               SlugHelpers.clear_conflicting_url_slugs(group_slug, "taken-slug")
+
+      # The url_slug was actually removed from the DB, so it no longer resolves.
+      assert DBStorage.find_by_url_slug(group_slug, "en-US", "taken-slug") == nil
     end
   end
 

--- a/test/phoenix_kit_publishing/web/controller/fallback_test.exs
+++ b/test/phoenix_kit_publishing/web/controller/fallback_test.exs
@@ -8,7 +8,11 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.FallbackTest do
 
   use PhoenixKitPublishing.ConnCase, async: false
 
+  alias PhoenixKit.Modules.Publishing.DBStorage
   alias PhoenixKit.Modules.Publishing.Groups
+  alias PhoenixKit.Modules.Publishing.Posts
+  alias PhoenixKit.Modules.Publishing.PublishingPost
+  alias PhoenixKit.Modules.Publishing.Versions
   alias PhoenixKit.Modules.Publishing.Web.Controller.Fallback
   alias PhoenixKit.Settings
 
@@ -119,6 +123,16 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.FallbackTest do
 
       assert path =~ "/" <> slug
     end
+
+    test "renders 404 (no redirect loop) for :module_disabled even when the group exists",
+         %{group_slug: slug} do
+      # Regression (H4): disabling the module routes requests here with reason
+      # :module_disabled. The group still exists in the DB, so the generic
+      # group-listing fallback would 302 to the same disabled URL forever.
+      conn = fake_conn(%{"group" => slug, "path" => []})
+
+      assert {:render_404} = Fallback.handle_not_found(conn, :module_disabled)
+    end
   end
 
   describe "find_any_available_language_version/3" do
@@ -137,6 +151,37 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.FallbackTest do
                slug,
                "2026-04-27",
                "10:00",
+               ["en"]
+             ) == :not_found
+    end
+
+    test "skips a future-dated published post so two languages don't 302-loop (H5)" do
+      # Regression: a future-dated post is 404'd as :unpublished by the renderer,
+      # but the language fallback only checked status == "published" — so two
+      # languages of the same future post would 302-ping-pong forever. The future
+      # gate must apply here too.
+      {:ok, group} =
+        Groups.add_group("FutureTS #{System.unique_integer([:positive])}", mode: "timestamp")
+
+      {:ok, post} = Posts.create_post(group["slug"], %{title: "Future Post"})
+
+      # Move the post into the future, then publish it.
+      future = Date.add(Date.utc_today(), 30)
+      repo = PhoenixKit.RepoHelper.repo()
+
+      repo.get_by(PublishingPost, uuid: post[:uuid])
+      |> Ecto.Changeset.change(post_date: future)
+      |> repo.update!()
+
+      [version] = DBStorage.list_versions(post[:uuid])
+      :ok = Versions.publish_version(group["slug"], post[:uuid], version.version_number)
+
+      time = post[:time] |> Time.to_string() |> String.slice(0, 5)
+
+      assert Fallback.find_first_published_timestamp_version(
+               group["slug"],
+               Date.to_iso8601(future),
+               time,
                ["en"]
              ) == :not_found
     end

--- a/test/phoenix_kit_publishing/web/controller/language_switcher_exposure_test.exs
+++ b/test/phoenix_kit_publishing/web/controller/language_switcher_exposure_test.exs
@@ -210,4 +210,30 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.LanguageSwitcherExposureT
       assert conn.assigns[:show_language_switcher] == true
     end
   end
+
+  describe "render-context assigns on every public branch (PR #15 consolidation)" do
+    # All four public render branches share `assign_publishing_render_context/2`
+    # (translations + :show_language_switcher). The listing + post branches are
+    # exercised above; this pins the previously-uncovered date-only branch so
+    # the consolidated helper can't silently regress it. (The versioned `/v/N`
+    # branch uses the identical helper call but only renders with
+    # `allow_version_access` enabled — its forwarding is covered by code
+    # identity rather than a dedicated version-access fixture here.)
+
+    test "date-only URL sets the render-context assigns", %{conn: conn} do
+      {:ok, ts_group} = Groups.add_group(unique_name(), mode: "timestamp")
+
+      {:ok, post} =
+        Posts.create_post(ts_group["slug"], %{title: "Timestamp Post", content: "Body."})
+
+      :ok = Versions.publish_version(ts_group["slug"], post.uuid, 1)
+
+      today = Date.to_iso8601(Date.utc_today())
+      conn = get(conn, "/" <> ts_group["slug"] <> "/" <> today)
+
+      assert html_response(conn, 200)
+      assert is_list(conn.assigns[:phoenix_kit_publishing_translations])
+      assert conn.assigns[:show_language_switcher] == true
+    end
+  end
 end

--- a/test/phoenix_kit_publishing/web/controller/rich_fixtures_test.exs
+++ b/test/phoenix_kit_publishing/web/controller/rich_fixtures_test.exs
@@ -75,7 +75,9 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.RichFixturesTest do
     test "renders show page for translated language (de-DE base 'de')",
          %{conn: conn, group_slug: group_slug, post: post} do
       conn = get(conn, "/de/#{group_slug}/#{post.slug}")
-      assert conn.status in [200, 301, 302, 404]
+      # The de-DE translation is in the published version, so it must be
+      # reachable — render or canonical-redirect, never 404.
+      assert conn.status in [200, 301, 302]
     end
 
     test "language fallback fires for unsupported language",

--- a/test/phoenix_kit_publishing/web/controller/slug_resolution_test.exs
+++ b/test/phoenix_kit_publishing/web/controller/slug_resolution_test.exs
@@ -120,5 +120,18 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.SlugResolutionTest do
       assert is_binary(url)
       assert url =~ "blog"
     end
+
+    test "builds the URL from a DB-shaped post map (no :mode/:date/:time/:language_slugs)" do
+      # `find_by_previous_url_slug/3` returns `db_content_to_post_map/1` shape,
+      # which only carries :slug/:url_slug/:language/:metadata. Before the fix the
+      # dot-access on :mode/:date/:time/:language_slugs raised KeyError, 500ing the
+      # 301 redirect instead of redirecting. Mode must default to slug mode here.
+      db_post = %{slug: "real", url_slug: "redirected", language: "en", metadata: %{}}
+
+      url = SlugResolution.build_post_redirect_url("blog", db_post, "en", "redirected")
+      assert is_binary(url)
+      assert url =~ "blog"
+      assert url =~ "redirected"
+    end
   end
 end

--- a/test/phoenix_kit_publishing/web/controller/slug_resolution_test.exs
+++ b/test/phoenix_kit_publishing/web/controller/slug_resolution_test.exs
@@ -133,5 +133,24 @@ defmodule PhoenixKit.Modules.Publishing.Web.Controller.SlugResolutionTest do
       assert url =~ "blog"
       assert url =~ "redirected"
     end
+
+    test "redirects a timestamp-mode DB-shaped post to its date URL, not a slug URL" do
+      # A timestamp-mode post reached via the previous-slug DB path carries its
+      # real :mode/:date now, so the 301 must land on the date URL — not a
+      # slug-mode URL (the bug from defaulting an absent mode to "slug").
+      db_post = %{
+        slug: "real",
+        url_slug: "real",
+        language: "en",
+        mode: "timestamp",
+        date: ~D[2024-03-15],
+        time: ~T[10:30:00],
+        metadata: %{}
+      }
+
+      url = SlugResolution.build_post_redirect_url("blog", db_post, "en", "real")
+      assert is_binary(url)
+      assert url =~ "2024-03-15"
+    end
   end
 end

--- a/test/phoenix_kit_publishing/web/editor/reload_version_test.exs
+++ b/test/phoenix_kit_publishing/web/editor/reload_version_test.exs
@@ -1,0 +1,53 @@
+defmodule PhoenixKit.Modules.Publishing.Web.Editor.ReloadVersionTest do
+  @moduledoc """
+  Regression test for H9 — editor reload paths must stay pinned to the version
+  the editor is on, not jump to the latest. `re_read_post/3` defaults its version
+  to the socket's `current_version`; without that, reloading a post with newer
+  versions would load the wrong version's content under a URL claiming the pinned
+  one and misdirect the next save.
+  """
+
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Modules.Publishing
+  alias PhoenixKit.Modules.Publishing.DBStorage
+  alias PhoenixKit.Modules.Publishing.Groups
+  alias PhoenixKit.Modules.Publishing.Posts
+  alias PhoenixKit.Modules.Publishing.Web.Editor.Persistence
+
+  test "reload_post stays pinned to current_version, not the latest version (H9)" do
+    {:ok, group} =
+      Groups.add_group("Reload #{System.unique_integer([:positive])}", mode: "slug")
+
+    {:ok, post} = Posts.create_post(group["slug"], %{title: "Reload Me", content: "v1 body"})
+
+    # A second (latest) version — left unpublished, so the post has no active
+    # version and a version-less read resolves to the LATEST (v2). This is the
+    # exact condition under which the un-pinned reload loaded the wrong version.
+    {:ok, _v2} = DBStorage.create_version_from(post[:uuid], 1)
+
+    lang = post[:language]
+    {:ok, v1_post} = Publishing.read_post_by_uuid(post[:uuid], lang, 1)
+    assert v1_post.version == 1
+
+    socket = %Phoenix.LiveView.Socket{
+      id: "reload-test",
+      assigns: %{
+        __changed__: %{},
+        flash: %{},
+        group_slug: group["slug"],
+        current_language: lang,
+        current_version: 1,
+        post: v1_post,
+        form: %{},
+        content: v1_post.content
+      }
+    }
+
+    result = Persistence.reload_post(socket)
+
+    # Pinned to v1. Before the fix, the version-less re-read resolved to the
+    # latest (v2) and the editor silently switched versions.
+    assert result.assigns.post.version == 1
+  end
+end

--- a/test/phoenix_kit_publishing/web/editor_live_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_live_test.exs
@@ -115,6 +115,28 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       assert is_binary(html)
     end
 
+    test "keeps the slug-truncation warning while the title stays over the URL cap",
+         %{conn: conn, group: group, post: post} do
+      {:ok, view, _html} =
+        conn
+        |> put_test_scope(fake_scope())
+        |> live("/admin/publishing/#{group["slug"]}/#{post[:uuid]}/edit")
+
+      long = String.duplicate("word ", 200)
+
+      # First over-cap keystroke surfaces the warning...
+      html = render_change(view, "update_meta", %{"title" => long, "_target" => ["title"]})
+      assert html =~ "the slug was shortened"
+
+      # ...and a further over-cap keystroke must NOT wipe it. `update_meta`
+      # clear_flash's up front, so the warning has to be re-asserted each time
+      # the slug is still truncated (a once-only guard used to drop it here).
+      html =
+        render_change(view, "update_meta", %{"title" => long <> " more", "_target" => ["title"]})
+
+      assert html =~ "the slug was shortened"
+    end
+
     test "switch_language event accepts the target language",
          %{conn: conn, group: group, post: post} do
       {:ok, view, _html} =
@@ -297,8 +319,10 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       # and the save errors. The flash must carry the reason via Errors.message,
       # never the old bare "Failed to save post". (The apostrophe in "Couldn't"
       # is HTML-escaped in the rendered output, so match the unambiguous tail.)
+      # We deliberately don't assert on the FK error wording itself — that's
+      # PostgreSQL's phrasing and brittle; the two assertions below prove the
+      # behaviour (descriptive flash, not the old bare message).
       assert html =~ "save this post."
-      assert html =~ "does not exist"
       refute html =~ "Failed to save post"
     end
 

--- a/test/phoenix_kit_publishing/web/editor_live_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_live_test.exs
@@ -313,6 +313,18 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       assert is_binary(html)
     end
 
+    test "switch_version with a non-integer param doesn't crash the LV (L1)",
+         %{conn: conn, group: group, post: post} do
+      {:ok, view, _html} =
+        conn
+        |> put_test_scope(fake_scope())
+        |> live("/admin/publishing/#{group["slug"]}/#{post[:uuid]}/edit")
+
+      # Before the fix this hit String.to_integer/1 and crashed the process.
+      html = render_click(view, "switch_version", %{"version" => "abc"})
+      assert is_binary(html)
+    end
+
     test "create_version_from_source builds a new version via Versions submodule",
          %{conn: conn, group: group, post: post} do
       {:ok, view, _html} =

--- a/test/phoenix_kit_publishing/web/editor_live_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_live_test.exs
@@ -255,6 +255,32 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       assert is_binary(html)
     end
 
+    test "saving a url_slug owned by another post shows the conflict modal (M13)",
+         %{conn: conn, group: group, post: post} do
+      # Another post already owns "taken-url-slug" (published).
+      {:ok, owner} = Posts.create_post(group["slug"], %{title: "Owner Post", slug: "owner-post"})
+      {:ok, _} = Posts.update_post(group["slug"], owner, %{"url_slug" => "taken-url-slug"}, %{})
+      :ok = Publishing.publish_version(group["slug"], owner[:uuid], 1)
+
+      {:ok, view, _html} =
+        conn
+        |> put_test_scope(fake_scope())
+        |> live("/admin/publishing/#{group["slug"]}/#{post[:uuid]}/edit")
+
+      _ =
+        render_change(view, "update_meta", %{
+          "url_slug" => "taken-url-slug",
+          "_target" => ["url_slug"]
+        })
+
+      html = render_click(view, "save", %{})
+
+      # The conflict modal appears and names the owning post (rather than silently
+      # clearing the slug or blocking with a bare flash).
+      assert html =~ "URL slug already in use"
+      assert html =~ "Owner Post"
+    end
+
     test "save failure surfaces a descriptive flash, not a bare generic one",
          %{conn: conn, group: group, post: post} do
       {:ok, view, _html} =

--- a/test/phoenix_kit_publishing/web/editor_live_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_live_test.exs
@@ -288,7 +288,7 @@ defmodule PhoenixKit.Modules.Publishing.Web.EditorLiveTest do
       _ = render_change(view, "update_meta", %{"title" => "", "_target" => ["title"]})
 
       html = render_click(view, "save", %{})
-      assert html =~ "required" || is_binary(html)
+      assert html =~ "Title is required to save."
     end
 
     test "switch_version to the same current version is a no-op",

--- a/test/phoenix_kit_publishing/web/editor_readonly_guards_test.exs
+++ b/test/phoenix_kit_publishing/web/editor_readonly_guards_test.exs
@@ -1,0 +1,65 @@
+defmodule PhoenixKit.Modules.Publishing.Web.EditorReadonlyGuardsTest do
+  @moduledoc """
+  Regression tests for H6 — read-only collaborative spectators must not be able
+  to drive any write path. Each handler below short-circuits on `readonly?: true`
+  and returns `{:noreply, socket}` without touching the DB. If a guard were
+  removed, the handler would fall through into its mutation path (perform_save /
+  enqueue_translation / create_version_from_source), which needs assigns + a DB
+  this bare socket doesn't have — so it would crash here rather than silently
+  letting a spectator clobber the lock owner's work.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Modules.Publishing.Web.Editor
+
+  defp readonly_socket(extra \\ %{}) do
+    %Phoenix.LiveView.Socket{
+      id: "test-socket-#{System.unique_integer([:positive])}",
+      assigns: Map.merge(%{__changed__: %{}, readonly?: true}, extra)
+    }
+  end
+
+  test "autosave is a no-op for a read-only spectator with pending changes" do
+    socket =
+      readonly_socket(%{
+        has_pending_changes: true,
+        translation_locked?: false,
+        is_autosaving: false,
+        autosave_timer: nil
+      })
+
+    assert {:noreply, result} = Editor.handle_info(:autosave, socket)
+    # The save branch sets is_autosaving: true; the guarded path must not.
+    refute result.assigns[:is_autosaving]
+  end
+
+  test "editor_content_changed is ignored for a read-only spectator" do
+    socket = readonly_socket(%{has_pending_changes: false})
+
+    assert {:noreply, result} =
+             Editor.handle_info({:editor_content_changed, %{content: "spectator edit"}}, socket)
+
+    # No dirty-tracking / autosave scheduling happened.
+    refute result.assigns[:has_pending_changes]
+  end
+
+  test "translate_to_all_languages is a no-op for a read-only spectator" do
+    assert {:noreply, _} =
+             Editor.handle_event("translate_to_all_languages", %{}, readonly_socket())
+  end
+
+  test "translate_missing_languages is a no-op for a read-only spectator" do
+    assert {:noreply, _} =
+             Editor.handle_event("translate_missing_languages", %{}, readonly_socket())
+  end
+
+  test "confirm_translation is a no-op for a read-only spectator" do
+    assert {:noreply, _} = Editor.handle_event("confirm_translation", %{}, readonly_socket())
+  end
+
+  test "create_version_from_source is a no-op for a read-only spectator" do
+    assert {:noreply, _} =
+             Editor.handle_event("create_version_from_source", %{}, readonly_socket())
+  end
+end

--- a/test/phoenix_kit_publishing/web/listing_live_test.exs
+++ b/test/phoenix_kit_publishing/web/listing_live_test.exs
@@ -37,8 +37,8 @@ defmodule PhoenixKit.Modules.Publishing.Web.ListingLiveTest do
       |> live("/admin/publishing/#{group["slug"]}")
 
     assert html =~ group["name"]
-    # Post body should be reachable in the rendered listing
-    assert html =~ post[:slug] || html =~ "Sample post"
+    # The post's title renders as its link in the listing.
+    assert html =~ "Sample post for listing"
   end
 
   test "switch_post_view toggles between active and trashed", %{conn: conn, group: group} do


### PR DESCRIPTION
A fresh-model adversarial audit of the whole module surfaced 9 High, 16 Medium, and 12 Low findings (+ nits). This PR fixes them, with a regression test pinning every behavioural change. Also folds in a Phase 1 catch-up on the PR #24 review. Suite **1137 tests, 0 failures** (integration tier running); `mix format`, `mix credo --strict`, `mix dialyzer` clean.

## High
H1 supervise the render cache · H2 write `previous_url_slugs` so 301s actually fire · H3 router host-route-hijack + GET/HEAD method gate · H4/H5 two infinite-redirect loops · H6 spectator write guards · H7 remove `<Hero>`/`<Page>` (resolved to core modules deleted with the Pages module) · H8 version dropdown (mapper field) · H9 reload version-pinning.

## Medium
M1 timestamp-collision retry (constraint-name match) · M2 trashed-slot availability · M3 transactional post update · M4 atomic publish + StaleFixer orphaned-version heal · M5 remove dead per-post SEO/OG scaffolding · M6 cross-group UUID access · M7 cross-node cache invalidation (clustering) · M8 supervised lock-table + crash-proof guard · M9 trash-not-delete + featured-image emptiness + ActivityLog · M10/M11/M12 code-region integrity / multi-line `<Image>` / consistent escaping · M13 incumbent-wins slug collisions + previous-slug containment + explain-and-link conflict modal · M14 remote-pid-safe presence (clustering) · M15 stale translation lock · M16 admin-insight cache flip.

## Low + nits
L1 switch_version crash · L2 preview save-failure · L3 unpublish pre-lock read · L4 transactional blank-version · L5 stamp timestamp posts in the site time zone · L6 group-rename cache invalidation · L7 erase whole cache on disable · L8 double-backtick code spans · L9 preserve unresolved `{{placeholder}}` · L10 token-scoped lock release · L11 narrowed update rescue · L12 fold timestamps into the posts term (cut `:persistent_term` churn) · title `phx-debounce` · canonical/302 query-string preservation · reserved route words on post/group slugs.

## PR #24 review catch-up (Phase 1)
- `humanize_field/1` keeps acronyms uppercased ("URL slug", "SEO title") instead of lowercasing them.
- Slug-truncation warning persists while the title stays over the URL cap (`update_meta`'s up-front `clear_flash` no longer drops it).
- Dropped an editor test assertion coupled to PostgreSQL's FK-error wording.
- In-page OpenGraph kept default-on (evaluated; default-off would strip OG tags from every vanilla install to protect an advanced host that already has a toggle).

## Notes
- No version bump / CHANGELOG — release is the maintainer's call.
- Docs: unique-index TODO in publishing `AGENTS.md`; signed file-URL hardening note in core `AGENTS.md`.
- After-action reports: `FOLLOW_UP.md` (audit) and `dev_docs/pull_requests/2026/24-editor-public-rendering-sweep/FOLLOW_UP.md` (Phase 1, alongside the read-only review).
- Open follow-ups (need a migration / core work): M13 inline cross-post slug edit; M13 unique-index + core signed-URLs.